### PR TITLE
fix: stabilize admin data handling and soft-delete behavior

### DIFF
--- a/src/main/java/ie/setu/hcs/controller/LoginController.java
+++ b/src/main/java/ie/setu/hcs/controller/LoginController.java
@@ -41,7 +41,7 @@ public class LoginController {
         }
 
         JFrame dashboard;
-        if (Boolean.TRUE.equals(account.isAdmin()) || Integer.valueOf(4).equals(account.getRoleId())) {
+        if (Integer.valueOf(4).equals(account.getRoleId())) {
             dashboard = new AdminDashboard(account);
         } else {
             dashboard = switch (account.getRoleId()) {

--- a/src/main/java/ie/setu/hcs/dao/impl/AccountDAOImpl.java
+++ b/src/main/java/ie/setu/hcs/dao/impl/AccountDAOImpl.java
@@ -23,15 +23,14 @@ public class AccountDAOImpl implements AccountDAO {
     public void save(Connection conn, Account account) throws SQLException {
         // creating sql variable with sql statement
         String sql = """
-                INSERT INTO accounts (email, password_hash, role_id, last_name, first_name, ppsn, phone, gender, is_active, created_at, is_admin)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                INSERT INTO accounts (email, password_hash, role_id, last_name, first_name, ppsn, phone, gender, is_active, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """;
 
         // validating connection
         // setting up connection with the database
         // creating PreparedStatement
         try (PreparedStatement pstmt = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
-            ensureAdminColumn(conn);
             // inserting arguments into the query statement
             pstmt.setString(1, account.getEmail());
             pstmt.setString(2, account.getPasswordHash());
@@ -43,7 +42,6 @@ public class AccountDAOImpl implements AccountDAO {
             pstmt.setString(8, account.getGender());
             pstmt.setBoolean(9, account.isActive());
             pstmt.setTimestamp(10, Timestamp.valueOf(account.getCreatedAt()));
-            pstmt.setBoolean(11, Boolean.TRUE.equals(account.isAdmin()));
 
             // executing the query in the database
             pstmt.executeUpdate();
@@ -69,7 +67,6 @@ public class AccountDAOImpl implements AccountDAO {
         // creating PreparedStatement
         try (Connection conn = DatabaseConfig.getConnection();
             PreparedStatement pstmt = conn.prepareStatement(sql)) {
-            ensureAdminColumn(conn);
             // inserting arguments into the query statement
             pstmt.setInt(1, id);
 
@@ -100,8 +97,6 @@ public class AccountDAOImpl implements AccountDAO {
         try (Connection conn = DatabaseConfig.getConnection();
         PreparedStatement pstmt = conn.prepareStatement(sql);
         ResultSet rs = pstmt.executeQuery()) {
-            ensureAdminColumn(conn);
-
             // returning the model from query
             return TableModelUtil.buildTableModel(rs);
         }
@@ -121,8 +116,7 @@ public class AccountDAOImpl implements AccountDAO {
                                     phone = ?,
                                     gender = ?,
                                     is_active = ?,
-                                    created_at = ?,
-                                    is_admin = ?
+                                    created_at = ?
                               WHERE account_id = ?
                 """;
 
@@ -131,7 +125,6 @@ public class AccountDAOImpl implements AccountDAO {
         // creating PreparedStatement
         try (Connection conn = DatabaseConfig.getConnection();
         PreparedStatement pstmt = conn.prepareStatement(sql)) {
-            ensureAdminColumn(conn);
             // inserting arguments into the query statement
             pstmt.setString(1, account.getEmail());
             pstmt.setString(2, account.getPasswordHash());
@@ -143,8 +136,7 @@ public class AccountDAOImpl implements AccountDAO {
             pstmt.setString(8, account.getGender());
             pstmt.setBoolean(9, account.isActive());
             pstmt.setTimestamp(10, Timestamp.valueOf(account.getCreatedAt()));
-            pstmt.setBoolean(11, Boolean.TRUE.equals(account.isAdmin()));
-            pstmt.setInt(12, account.getAccountId());
+            pstmt.setInt(11, account.getAccountId());
 
             // execute the query
             pstmt.executeUpdate();
@@ -186,7 +178,6 @@ public class AccountDAOImpl implements AccountDAO {
         // creating PreparedStatement
         try (Connection conn = DatabaseConfig.getConnection();
              PreparedStatement pstmt = conn.prepareStatement(sql)) {
-            ensureAdminColumn(conn);
             // inserting arguments into the query statement
             pstmt.setString(1, email);
 
@@ -215,7 +206,6 @@ public class AccountDAOImpl implements AccountDAO {
         // creating PreparedStatement
         try (Connection conn = DatabaseConfig.getConnection();
              PreparedStatement pstmt = conn.prepareStatement(sql)) {
-            ensureAdminColumn(conn);
             // inserting arguments into the query statement
             pstmt.setString(1, email);
 
@@ -244,8 +234,6 @@ public class AccountDAOImpl implements AccountDAO {
         // creating PreparedStatement
         try (Connection conn = DatabaseConfig.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
-            ensureAdminColumn(conn);
-
             // inserting arguments into the query statement
             ps.setInt(1, roleId);
 
@@ -323,10 +311,6 @@ public class AccountDAOImpl implements AccountDAO {
         account.setActive(
                 rs.getBoolean("is_active"));
 
-        // mapping is_admin to an object
-        account.setAdmin(
-                rs.getBoolean("is_admin"));
-
         // taking timestamp from the result set
         Timestamp timestamp =
                 rs.getTimestamp("created_at");
@@ -340,25 +324,5 @@ public class AccountDAOImpl implements AccountDAO {
 
         // returning the account information
         return account;
-    }
-
-    private void ensureAdminColumn(Connection conn) throws SQLException {
-        if (hasColumn(conn, "is_admin")) {
-            return;
-        }
-
-        try (Statement stmt = conn.createStatement()) {
-            stmt.executeUpdate("ALTER TABLE accounts ADD COLUMN is_admin BOOLEAN NOT NULL DEFAULT FALSE");
-        } catch (SQLException ex) {
-            if (!hasColumn(conn, "is_admin")) {
-                throw ex;
-            }
-        }
-    }
-
-    private boolean hasColumn(Connection conn, String columnName) throws SQLException {
-        try (ResultSet columns = conn.getMetaData().getColumns(conn.getCatalog(), null, "accounts", columnName)) {
-            return columns.next();
-        }
     }
 }

--- a/src/main/java/ie/setu/hcs/dao/impl/AppointmentDAOImpl.java
+++ b/src/main/java/ie/setu/hcs/dao/impl/AppointmentDAOImpl.java
@@ -52,7 +52,11 @@ public class AppointmentDAOImpl implements AppointmentDAO {
     @Override
     public Appointment findById(Integer id) throws SQLException {
         // creating sql variable with sql statement
-        String sql = "SELECT * FROM appointments WHERE appointment_id = ?";
+        String sql = """
+                SELECT * FROM appointments
+                WHERE appointment_id = ?
+                  AND COALESCE(delete_flag, FALSE) = FALSE
+                """;
 
         // validate connection
         // setting up connection with database
@@ -81,19 +85,20 @@ public class AppointmentDAOImpl implements AppointmentDAO {
     @Override
     public DefaultTableModel findAll() throws SQLException {
         // creating sql variable with sql statement
-        String sql = "SELECT * FROM appointments";
+        String sql = "SELECT * FROM appointments WHERE COALESCE(delete_flag, FALSE) = FALSE";
 
         // validate connection
         // setting up connection with database
         // creating PreparedStatement
         // executing the query
-        try (Connection conn = DatabaseConfig.getConnection();
-        PreparedStatement pstmt = conn.prepareStatement(sql);
-        ResultSet rs = pstmt.executeQuery()) {
+        try (Connection conn = DatabaseConfig.getConnection()) {
             ensureOptionalColumns(conn);
+            try (PreparedStatement pstmt = conn.prepareStatement(sql);
+                 ResultSet rs = pstmt.executeQuery()) {
 
-            // returning the model from query
-            return TableModelUtil.buildTableModel(rs);
+                // returning the model from query
+                return TableModelUtil.buildTableModel(rs);
+            }
         }
     }
 
@@ -110,6 +115,7 @@ public class AppointmentDAOImpl implements AppointmentDAO {
                status
         FROM appointments
         WHERE patient_id = ?
+          AND COALESCE(delete_flag, FALSE) = FALSE
           AND appointment_datetime >= NOW()
           AND status IN ('Pending', 'Accepted')
         ORDER BY appointment_datetime
@@ -145,6 +151,7 @@ public class AppointmentDAOImpl implements AppointmentDAO {
                                         medical_need = ?,
                                         consultation_room = ?
                                   WHERE appointment_id = ?
+                                    AND COALESCE(delete_flag, FALSE) = FALSE
                 """;
 
         // validate connection
@@ -171,13 +178,19 @@ public class AppointmentDAOImpl implements AppointmentDAO {
     @Override
     public void delete(Integer id) throws SQLException {
         // creating sql variable with sql statement
-        String sql = "DELETE FROM appointments WHERE appointment_id = ?";
+        String sql = """
+                UPDATE appointments
+                SET delete_flag = TRUE
+                WHERE appointment_id = ?
+                  AND COALESCE(delete_flag, FALSE) = FALSE
+                """;
 
         // validate connection
         // setting up connection with database
         // creating PreparedStatement
         try (Connection conn = DatabaseConfig.getConnection();
              PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            ensureOptionalColumns(conn);
             // inserting arguments into the query statement
             pstmt.setInt(1, id);
 
@@ -193,7 +206,7 @@ public class AppointmentDAOImpl implements AppointmentDAO {
 
         // creating sql variable with sql statement
         String sql =
-                "SELECT * FROM appointments WHERE patient_id = ?";
+                "SELECT * FROM appointments WHERE patient_id = ? AND COALESCE(delete_flag, FALSE) = FALSE";
 
         // validate connection
         // setting up connection with database
@@ -221,7 +234,7 @@ public class AppointmentDAOImpl implements AppointmentDAO {
 
         // creating sql variable with sql statement
         String sql =
-                "SELECT * FROM appointments WHERE doctor_id = ?";
+                "SELECT * FROM appointments WHERE doctor_id = ? AND COALESCE(delete_flag, FALSE) = FALSE";
 
         // validate connection
         // setting up connection with database
@@ -249,7 +262,7 @@ public class AppointmentDAOImpl implements AppointmentDAO {
 
         // creating sql variable with sql statement
         String sql =
-                "SELECT * FROM appointments WHERE status = ?";
+                "SELECT * FROM appointments WHERE status = ? AND COALESCE(delete_flag, FALSE) = FALSE";
 
         // validate connection
         // setting up connection with database
@@ -278,7 +291,7 @@ public class AppointmentDAOImpl implements AppointmentDAO {
 
         // creating sql variable with sql statement
         String sql =
-                "UPDATE appointments SET status = ? WHERE appointment_id = ?";
+                "UPDATE appointments SET status = ? WHERE appointment_id = ? AND COALESCE(delete_flag, FALSE) = FALSE";
 
         // validate connection
         // setting up connection with database
@@ -347,6 +360,7 @@ public class AppointmentDAOImpl implements AppointmentDAO {
     private void ensureOptionalColumns(Connection conn) throws SQLException {
         ensureColumn(conn, "medical_need", "ALTER TABLE appointments ADD COLUMN medical_need TEXT NULL");
         ensureColumn(conn, "consultation_room", "ALTER TABLE appointments ADD COLUMN consultation_room VARCHAR(120) NULL");
+        ensureColumn(conn, "delete_flag", "ALTER TABLE appointments ADD COLUMN delete_flag BOOLEAN NOT NULL DEFAULT FALSE");
     }
 
     private void ensureColumn(Connection conn, String columnName, String alterSql) throws SQLException {

--- a/src/main/java/ie/setu/hcs/dao/impl/ConsultationDAOImpl.java
+++ b/src/main/java/ie/setu/hcs/dao/impl/ConsultationDAOImpl.java
@@ -26,6 +26,7 @@ public class ConsultationDAOImpl implements ConsultationDAO {
         // creating PreparedStatement
         try (Connection conn = DatabaseConfig.getConnection();
              PreparedStatement pstmt = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            ensureDeleteFlagColumn(conn);
             // inserting arguments into the query statement
             pstmt.setInt(1, consultation.getAppointmentId());
             pstmt.setString(2, consultation.getDiagnosis());
@@ -49,13 +50,18 @@ public class ConsultationDAOImpl implements ConsultationDAO {
     @Override
     public Consultation findById(Integer id) throws SQLException {
         // creating sql variable with sql statement
-        String sql = "SELECT * FROM consultation WHERE consultation_id = ?";
+        String sql = """
+                SELECT * FROM consultation
+                WHERE consultation_id = ?
+                  AND COALESCE(delete_flag, FALSE) = FALSE
+                """;
 
         // validate connection
         // setting up connection with database
         // creating PreparedStatement
         try (Connection conn = DatabaseConfig.getConnection();
              PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            ensureDeleteFlagColumn(conn);
             // inserting arguments into the query statement
             pstmt.setInt(1, id);
 
@@ -77,18 +83,20 @@ public class ConsultationDAOImpl implements ConsultationDAO {
     @Override
     public DefaultTableModel findAll() throws SQLException {
         // creating sql variable with sql statement
-        String sql = "SELECT * FROM consultation";
+        String sql = "SELECT * FROM consultation WHERE COALESCE(delete_flag, FALSE) = FALSE";
 
         // validate connection
         // setting up connection with database
         // creating PreparedStatement
         // executing the query
-        try (Connection conn = DatabaseConfig.getConnection();
-             PreparedStatement pstmt = conn.prepareStatement(sql);
-             ResultSet rs = pstmt.executeQuery()) {
+        try (Connection conn = DatabaseConfig.getConnection()) {
+            ensureDeleteFlagColumn(conn);
+            try (PreparedStatement pstmt = conn.prepareStatement(sql);
+                 ResultSet rs = pstmt.executeQuery()) {
 
-            // returning the model from query
-            return TableModelUtil.buildTableModel(rs);
+                // returning the model from query
+                return TableModelUtil.buildTableModel(rs);
+            }
         }
     }
 
@@ -102,6 +110,7 @@ public class ConsultationDAOImpl implements ConsultationDAO {
                                         notes = ?,
                                         created_at = ?
                               WHERE consultation_id = ?
+                                AND COALESCE(delete_flag, FALSE) = FALSE
                 """;
 
         // validate connection
@@ -109,6 +118,7 @@ public class ConsultationDAOImpl implements ConsultationDAO {
         // creating PreparedStatement
         try (Connection conn = DatabaseConfig.getConnection();
              PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            ensureDeleteFlagColumn(conn);
             // inserting arguments into the query statement
             pstmt.setInt(1, consultation.getAppointmentId());
             pstmt.setString(2, consultation.getDiagnosis());
@@ -125,13 +135,19 @@ public class ConsultationDAOImpl implements ConsultationDAO {
     @Override
     public void delete(Integer id) throws SQLException {
         // creating sql variable with sql statement
-        String sql = "DELETE FROM consultation WHERE consultation_id = ?";
+        String sql = """
+                UPDATE consultation
+                SET delete_flag = TRUE
+                WHERE consultation_id = ?
+                  AND COALESCE(delete_flag, FALSE) = FALSE
+                """;
 
         // validate connection
         // setting up connection with database
         // creating PreparedStatement
         try (Connection conn = DatabaseConfig.getConnection();
              PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            ensureDeleteFlagColumn(conn);
             // inserting arguments into the query statement
             pstmt.setInt(1, id);
 
@@ -144,13 +160,18 @@ public class ConsultationDAOImpl implements ConsultationDAO {
     @Override
     public Consultation findByAppointmentId(Integer appointmentId) throws SQLException {
         // creating sql variable with sql statement
-        String sql = "SELECT * FROM consultation WHERE appointment_id = ?";
+        String sql = """
+                SELECT * FROM consultation
+                WHERE appointment_id = ?
+                  AND COALESCE(delete_flag, FALSE) = FALSE
+                """;
 
         // validate connection
         // setting up connection with database
         // creating PreparedStatement
         try (Connection conn = DatabaseConfig.getConnection();
              PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            ensureDeleteFlagColumn(conn);
             // inserting arguments into the query statement
             pstmt.setInt(1, appointmentId);
 
@@ -176,6 +197,8 @@ public class ConsultationDAOImpl implements ConsultationDAO {
                 SELECT c.* FROM consultation c
                 JOIN appointments a ON c.appointment_id = a.appointment_id
                 WHERE a.patient_id = ?
+                  AND COALESCE(c.delete_flag, FALSE) = FALSE
+                  AND COALESCE(a.delete_flag, FALSE) = FALSE
                 """;
 
         // validate connection
@@ -183,6 +206,8 @@ public class ConsultationDAOImpl implements ConsultationDAO {
         // creating PreparedStatement
         try (Connection conn = DatabaseConfig.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
+            ensureDeleteFlagColumn(conn);
+            ensureAppointmentDeleteFlagColumn(conn);
 
             // inserting arguments into the query statement
             ps.setInt(1, patientId);
@@ -231,5 +256,35 @@ public class ConsultationDAOImpl implements ConsultationDAO {
 
         // returning the consultation information
         return consultation;
+    }
+
+    private void ensureDeleteFlagColumn(Connection conn) throws SQLException {
+        ensureColumn(conn, "consultation", "delete_flag",
+                "ALTER TABLE consultation ADD COLUMN delete_flag BOOLEAN NOT NULL DEFAULT FALSE");
+    }
+
+    private void ensureAppointmentDeleteFlagColumn(Connection conn) throws SQLException {
+        ensureColumn(conn, "appointments", "delete_flag",
+                "ALTER TABLE appointments ADD COLUMN delete_flag BOOLEAN NOT NULL DEFAULT FALSE");
+    }
+
+    private void ensureColumn(Connection conn, String tableName, String columnName, String alterSql) throws SQLException {
+        if (hasColumn(conn, tableName, columnName)) {
+            return;
+        }
+
+        try (Statement stmt = conn.createStatement()) {
+            stmt.executeUpdate(alterSql);
+        } catch (SQLException ex) {
+            if (!hasColumn(conn, tableName, columnName)) {
+                throw ex;
+            }
+        }
+    }
+
+    private boolean hasColumn(Connection conn, String tableName, String columnName) throws SQLException {
+        try (ResultSet columns = conn.getMetaData().getColumns(conn.getCatalog(), null, tableName, columnName)) {
+            return columns.next();
+        }
     }
 }

--- a/src/main/java/ie/setu/hcs/dao/impl/DoctorDAOImpl.java
+++ b/src/main/java/ie/setu/hcs/dao/impl/DoctorDAOImpl.java
@@ -293,20 +293,43 @@ public class DoctorDAOImpl implements DoctorDAO {
     private void ensureEmployeeNumColumn(Connection conn) throws SQLException {
         try (ResultSet columns = conn.getMetaData().getColumns(conn.getCatalog(), null, "doctors", "employee_num")) {
             if (columns.next()) {
+                int dataType = columns.getInt("DATA_TYPE");
+                if (dataType == Types.VARCHAR || dataType == Types.CHAR
+                        || dataType == Types.LONGVARCHAR || dataType == Types.NVARCHAR
+                        || dataType == Types.NCHAR || dataType == Types.LONGNVARCHAR) {
+                    return;
+                }
+                alterEmployeeNumColumn(conn);
                 return;
             }
         }
 
+        addEmployeeNumColumn(conn);
+    }
+
+    private void addEmployeeNumColumn(Connection conn) throws SQLException {
         try (PreparedStatement pstmt =
                      conn.prepareStatement("ALTER TABLE doctors ADD COLUMN employee_num VARCHAR(50) NULL AFTER account_id")) {
             pstmt.executeUpdate();
         } catch (SQLException ex) {
             try (ResultSet columns = conn.getMetaData().getColumns(conn.getCatalog(), null, "doctors", "employee_num")) {
                 if (columns.next()) {
-                    return;
+                    int dataType = columns.getInt("DATA_TYPE");
+                    if (dataType == Types.VARCHAR || dataType == Types.CHAR
+                            || dataType == Types.LONGVARCHAR || dataType == Types.NVARCHAR
+                            || dataType == Types.NCHAR || dataType == Types.LONGNVARCHAR) {
+                        return;
+                    }
                 }
             }
             throw ex;
+        }
+    }
+
+    private void alterEmployeeNumColumn(Connection conn) throws SQLException {
+        try (PreparedStatement pstmt =
+                     conn.prepareStatement("ALTER TABLE doctors MODIFY COLUMN employee_num VARCHAR(50) NULL")) {
+            pstmt.executeUpdate();
         }
     }
 }

--- a/src/main/java/ie/setu/hcs/dao/impl/InsuranceDAOImpl.java
+++ b/src/main/java/ie/setu/hcs/dao/impl/InsuranceDAOImpl.java
@@ -26,7 +26,7 @@ public class InsuranceDAOImpl implements InsuranceDAO {
         // creating PreparedStatement
         try (Connection conn = DatabaseConfig.getConnection();
              PreparedStatement pstmt = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
-            ensureCardDocumentColumn(conn);
+            ensureOptionalColumns(conn);
             // inserting arguments into the query statement
             pstmt.setInt(1, insurance.getPatientId());
             pstmt.setString(2, insurance.getProviderName());
@@ -52,14 +52,18 @@ public class InsuranceDAOImpl implements InsuranceDAO {
     @Override
     public Insurance findById(Integer id) throws SQLException {
         // creating sql variable with sql statement
-        String sql = "SELECT * FROM insurance WHERE insurance_id = ?";
+        String sql = """
+                SELECT * FROM insurance
+                WHERE insurance_id = ?
+                  AND COALESCE(delete_flag, FALSE) = FALSE
+                """;
 
         // validate connection
         // setting up connection with database
         // creating PreparedStatement
         try (Connection conn = DatabaseConfig.getConnection();
              PreparedStatement pstmt = conn.prepareStatement(sql)) {
-            ensureCardDocumentColumn(conn);
+            ensureOptionalColumns(conn);
             // inserting arguments into the query statement
             pstmt.setInt(1, id);
 
@@ -81,19 +85,20 @@ public class InsuranceDAOImpl implements InsuranceDAO {
     @Override
     public DefaultTableModel findAll() throws SQLException {
         // creating sql variable with sql statement
-        String sql = "SELECT * FROM insurance";
+        String sql = "SELECT * FROM insurance WHERE COALESCE(delete_flag, FALSE) = FALSE";
 
         // validate connection
         // setting up connection with database
         // creating PreparedStatement
         // executing the query
-        try (Connection conn = DatabaseConfig.getConnection();
-             PreparedStatement pstmt = conn.prepareStatement(sql);
-             ResultSet rs = pstmt.executeQuery()) {
-            ensureCardDocumentColumn(conn);
+        try (Connection conn = DatabaseConfig.getConnection()) {
+            ensureOptionalColumns(conn);
+            try (PreparedStatement pstmt = conn.prepareStatement(sql);
+                 ResultSet rs = pstmt.executeQuery()) {
 
-            // returning the model from query
-            return TableModelUtil.buildTableModel(rs);
+                // returning the model from query
+                return TableModelUtil.buildTableModel(rs);
+            }
         }
     }
 
@@ -109,6 +114,7 @@ public class InsuranceDAOImpl implements InsuranceDAO {
                                       expiration_date = ?,
                                       card_document_path = ?
                               WHERE insurance_id = ?
+                                AND COALESCE(delete_flag, FALSE) = FALSE
                 """;
 
         // validate connection
@@ -116,7 +122,7 @@ public class InsuranceDAOImpl implements InsuranceDAO {
         // creating PreparedStatement
         try (Connection conn = DatabaseConfig.getConnection();
              PreparedStatement pstmt = conn.prepareStatement(sql)) {
-            ensureCardDocumentColumn(conn);
+            ensureOptionalColumns(conn);
             // inserting arguments into the query statement
             pstmt.setInt(1, insurance.getPatientId());
             pstmt.setString(2, insurance.getProviderName());
@@ -135,13 +141,19 @@ public class InsuranceDAOImpl implements InsuranceDAO {
     @Override
     public void delete(Integer id) throws SQLException {
         // creating sql variable with sql statement
-        String sql = "DELETE FROM insurance WHERE insurance_id = ?";
+        String sql = """
+                UPDATE insurance
+                SET delete_flag = TRUE
+                WHERE insurance_id = ?
+                  AND COALESCE(delete_flag, FALSE) = FALSE
+                """;
 
         // validate connection
         // setting up connection with database
         // creating PreparedStatement
         try (Connection conn = DatabaseConfig.getConnection();
              PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            ensureOptionalColumns(conn);
             // inserting arguments into the query statement
             pstmt.setInt(1, id);
 
@@ -154,14 +166,14 @@ public class InsuranceDAOImpl implements InsuranceDAO {
     @Override
     public DefaultTableModel findByPatientId(Integer patientId) throws SQLException {
         // creating sql variable with sql statement
-        String sql = "SELECT * FROM insurance WHERE patient_id = ?";
+        String sql = "SELECT * FROM insurance WHERE patient_id = ? AND COALESCE(delete_flag, FALSE) = FALSE";
 
         // validate connection
         // setting up connection with database
         // creating PreparedStatement
         try (Connection conn = DatabaseConfig.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
-            ensureCardDocumentColumn(conn);
+            ensureOptionalColumns(conn);
 
             // inserting arguments into the query statement
             ps.setInt(1, patientId);
@@ -178,14 +190,19 @@ public class InsuranceDAOImpl implements InsuranceDAO {
     @Override
     public void updateStatus(Integer insuranceId, String status) throws SQLException {
         // creating sql variable with sql statement
-        String sql = "UPDATE insurance SET status = ? WHERE insurance_id = ?";
+        String sql = """
+                UPDATE insurance
+                SET status = ?
+                WHERE insurance_id = ?
+                  AND COALESCE(delete_flag, FALSE) = FALSE
+                """;
 
         // validate connection
         // setting up connection with database
         // creating PreparedStatement
         try (Connection conn = DatabaseConfig.getConnection();
              PreparedStatement pstmt = conn.prepareStatement(sql)) {
-            ensureCardDocumentColumn(conn);
+            ensureOptionalColumns(conn);
             // inserting arguments into the query statement
             pstmt.setString(1, status);
             pstmt.setInt(2, insuranceId);
@@ -240,15 +257,20 @@ public class InsuranceDAOImpl implements InsuranceDAO {
         return insurance;
     }
 
-    private void ensureCardDocumentColumn(Connection conn) throws SQLException {
-        if (hasColumn(conn, "card_document_path")) {
+    private void ensureOptionalColumns(Connection conn) throws SQLException {
+        ensureColumn(conn, "card_document_path", "ALTER TABLE insurance ADD COLUMN card_document_path VARCHAR(500) NULL");
+        ensureColumn(conn, "delete_flag", "ALTER TABLE insurance ADD COLUMN delete_flag BOOLEAN NOT NULL DEFAULT FALSE");
+    }
+
+    private void ensureColumn(Connection conn, String columnName, String alterSql) throws SQLException {
+        if (hasColumn(conn, columnName)) {
             return;
         }
 
         try (Statement stmt = conn.createStatement()) {
-            stmt.executeUpdate("ALTER TABLE insurance ADD COLUMN card_document_path VARCHAR(500) NULL");
+            stmt.executeUpdate(alterSql);
         } catch (SQLException ex) {
-            if (!hasColumn(conn, "card_document_path")) {
+            if (!hasColumn(conn, columnName)) {
                 throw ex;
             }
         }

--- a/src/main/java/ie/setu/hcs/dao/impl/InvoiceDAOImpl.java
+++ b/src/main/java/ie/setu/hcs/dao/impl/InvoiceDAOImpl.java
@@ -26,6 +26,7 @@ public class InvoiceDAOImpl implements InvoiceDAO {
         // creating PreparedStatement
         try (Connection conn = DatabaseConfig.getConnection();
              PreparedStatement pstmt = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            ensureDeleteFlagColumn(conn);
             // inserting arguments into the query statement
             pstmt.setInt(1, invoice.getPatientId());
             pstmt.setInt(2, invoice.getConsultationId());
@@ -51,13 +52,18 @@ public class InvoiceDAOImpl implements InvoiceDAO {
     @Override
     public Invoice findById(Integer id) throws SQLException {
         // creating sql variable with sql statement
-        String sql = "SELECT * FROM invoices WHERE invoice_id = ?";
+        String sql = """
+                SELECT * FROM invoices
+                WHERE invoice_id = ?
+                  AND COALESCE(delete_flag, FALSE) = FALSE
+                """;
 
         // validate connection
         // setting up connection with database
         // creating PreparedStatement
         try (Connection conn = DatabaseConfig.getConnection();
              PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            ensureDeleteFlagColumn(conn);
             // inserting arguments into the query statement
             pstmt.setInt(1, id);
 
@@ -79,18 +85,20 @@ public class InvoiceDAOImpl implements InvoiceDAO {
     @Override
     public DefaultTableModel findAll() throws SQLException {
         // creating sql variable with sql statement
-        String sql = "SELECT * FROM invoices";
+        String sql = "SELECT * FROM invoices WHERE COALESCE(delete_flag, FALSE) = FALSE";
 
         // validate connection
         // setting up connection with database
         // creating PreparedStatement
         // executing the query
-        try (Connection conn = DatabaseConfig.getConnection();
-             PreparedStatement pstmt = conn.prepareStatement(sql);
-             ResultSet rs = pstmt.executeQuery()) {
+        try (Connection conn = DatabaseConfig.getConnection()) {
+            ensureDeleteFlagColumn(conn);
+            try (PreparedStatement pstmt = conn.prepareStatement(sql);
+                 ResultSet rs = pstmt.executeQuery()) {
 
-            // returning the model from query
-            return TableModelUtil.buildTableModel(rs);
+                // returning the model from query
+                return TableModelUtil.buildTableModel(rs);
+            }
         }
     }
 
@@ -106,6 +114,7 @@ public class InvoiceDAOImpl implements InvoiceDAO {
                                     issued_at = ?,
                                     paid_at = ?
                               WHERE invoice_id = ?
+                                AND COALESCE(delete_flag, FALSE) = FALSE
                 """;
 
         // validate connection
@@ -113,6 +122,7 @@ public class InvoiceDAOImpl implements InvoiceDAO {
         // creating PreparedStatement
         try (Connection conn = DatabaseConfig.getConnection();
              PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            ensureDeleteFlagColumn(conn);
             // inserting arguments into the query statement
             pstmt.setInt(1, invoice.getPatientId());
             pstmt.setInt(2, invoice.getConsultationId());
@@ -131,13 +141,19 @@ public class InvoiceDAOImpl implements InvoiceDAO {
     @Override
     public void delete(Integer id) throws SQLException {
         // creating sql variable with sql statement
-        String sql = "DELETE FROM invoices WHERE invoice_id = ?";
+        String sql = """
+                UPDATE invoices
+                SET delete_flag = TRUE
+                WHERE invoice_id = ?
+                  AND COALESCE(delete_flag, FALSE) = FALSE
+                """;
 
         // validate connection
         // setting up connection with database
         // creating PreparedStatement
         try (Connection conn = DatabaseConfig.getConnection();
              PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            ensureDeleteFlagColumn(conn);
             // inserting arguments into the query statement
             pstmt.setInt(1, id);
 
@@ -150,13 +166,14 @@ public class InvoiceDAOImpl implements InvoiceDAO {
     @Override
     public DefaultTableModel findByPatientId(Integer patientId) throws SQLException {
         // creating sql variable with sql statement
-        String sql = "SELECT * FROM invoices WHERE patient_id = ?";
+        String sql = "SELECT * FROM invoices WHERE patient_id = ? AND COALESCE(delete_flag, FALSE) = FALSE";
 
         // validate connection
         // setting up connection with database
         // creating PreparedStatement
         try (Connection conn = DatabaseConfig.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
+            ensureDeleteFlagColumn(conn);
 
             // inserting arguments into the query statement
             ps.setInt(1, patientId);
@@ -173,13 +190,14 @@ public class InvoiceDAOImpl implements InvoiceDAO {
     @Override
     public DefaultTableModel findByConsultationId(Integer consultationId) throws SQLException {
         // creating sql variable with sql statement
-        String sql = "SELECT * FROM invoices WHERE consultation_id = ?";
+        String sql = "SELECT * FROM invoices WHERE consultation_id = ? AND COALESCE(delete_flag, FALSE) = FALSE";
 
         // validate connection
         // setting up connection with database
         // creating PreparedStatement
         try (Connection conn = DatabaseConfig.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
+            ensureDeleteFlagColumn(conn);
 
             // inserting arguments into the query statement
             ps.setInt(1, consultationId);
@@ -196,13 +214,19 @@ public class InvoiceDAOImpl implements InvoiceDAO {
     @Override
     public void markAsPaid(Integer invoiceId) throws SQLException {
         // creating sql variable with sql statement
-        String sql = "UPDATE invoices SET invoice_status = ?, paid_at = ? WHERE invoice_id = ?";
+        String sql = """
+                UPDATE invoices
+                SET invoice_status = ?, paid_at = ?
+                WHERE invoice_id = ?
+                  AND COALESCE(delete_flag, FALSE) = FALSE
+                """;
 
         // validate connection
         // setting up connection with database
         // creating PreparedStatement
         try (Connection conn = DatabaseConfig.getConnection();
              PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            ensureDeleteFlagColumn(conn);
             // inserting arguments into the query statement
             pstmt.setString(1, "PAID");
             pstmt.setTimestamp(2, Timestamp.valueOf(java.time.LocalDateTime.now()));
@@ -217,13 +241,19 @@ public class InvoiceDAOImpl implements InvoiceDAO {
     @Override
     public DefaultTableModel findUnpaidByPatientId(Integer patientId) throws SQLException {
         // creating sql variable with sql statement
-        String sql = "SELECT * FROM invoices WHERE patient_id = ? AND invoice_status != 'PAID'";
+        String sql = """
+                SELECT * FROM invoices
+                WHERE patient_id = ?
+                  AND invoice_status != 'PAID'
+                  AND COALESCE(delete_flag, FALSE) = FALSE
+                """;
 
         // validate connection
         // setting up connection with database
         // creating PreparedStatement
         try (Connection conn = DatabaseConfig.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
+            ensureDeleteFlagColumn(conn);
 
             // inserting arguments into the query statement
             ps.setInt(1, patientId);
@@ -287,5 +317,25 @@ public class InvoiceDAOImpl implements InvoiceDAO {
 
         // returning the invoice information
         return invoice;
+    }
+
+    private void ensureDeleteFlagColumn(Connection conn) throws SQLException {
+        if (hasColumn(conn, "delete_flag")) {
+            return;
+        }
+
+        try (Statement stmt = conn.createStatement()) {
+            stmt.executeUpdate("ALTER TABLE invoices ADD COLUMN delete_flag BOOLEAN NOT NULL DEFAULT FALSE");
+        } catch (SQLException ex) {
+            if (!hasColumn(conn, "delete_flag")) {
+                throw ex;
+            }
+        }
+    }
+
+    private boolean hasColumn(Connection conn, String columnName) throws SQLException {
+        try (ResultSet columns = conn.getMetaData().getColumns(conn.getCatalog(), null, "invoices", columnName)) {
+            return columns.next();
+        }
     }
 }

--- a/src/main/java/ie/setu/hcs/dao/impl/LabResultDAOImpl.java
+++ b/src/main/java/ie/setu/hcs/dao/impl/LabResultDAOImpl.java
@@ -26,7 +26,7 @@ public class LabResultDAOImpl implements LabResultDAO {
         // creating PreparedStatement
         try (Connection conn = DatabaseConfig.getConnection();
              PreparedStatement pstmt = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
-            ensureAppointmentIdColumn(conn);
+            ensureOptionalColumns(conn);
             // inserting arguments into the query statement
             if (labResult.getConsultationId() == null) {
                 pstmt.setNull(1, Types.INTEGER);
@@ -60,14 +60,18 @@ public class LabResultDAOImpl implements LabResultDAO {
     @Override
     public LabResult findById(Integer id) throws SQLException {
         // creating sql variable with sql statement
-        String sql = "SELECT * FROM lab_results WHERE lab_result_id = ?";
+        String sql = """
+                SELECT * FROM lab_results
+                WHERE lab_result_id = ?
+                  AND COALESCE(delete_flag, FALSE) = FALSE
+                """;
 
         // validate connection
         // setting up connection with database
         // creating PreparedStatement
         try (Connection conn = DatabaseConfig.getConnection();
              PreparedStatement pstmt = conn.prepareStatement(sql)) {
-            ensureAppointmentIdColumn(conn);
+            ensureOptionalColumns(conn);
             // inserting arguments into the query statement
             pstmt.setInt(1, id);
 
@@ -89,19 +93,20 @@ public class LabResultDAOImpl implements LabResultDAO {
     @Override
     public DefaultTableModel findAll() throws SQLException {
         // creating sql variable with sql statement
-        String sql = "SELECT * FROM lab_results";
+        String sql = "SELECT * FROM lab_results WHERE COALESCE(delete_flag, FALSE) = FALSE";
 
         // validate connection
         // setting up connection with database
         // creating PreparedStatement
         // executing the query
-        try (Connection conn = DatabaseConfig.getConnection();
-             PreparedStatement pstmt = conn.prepareStatement(sql);
-             ResultSet rs = pstmt.executeQuery()) {
-            ensureAppointmentIdColumn(conn);
+        try (Connection conn = DatabaseConfig.getConnection()) {
+            ensureOptionalColumns(conn);
+            try (PreparedStatement pstmt = conn.prepareStatement(sql);
+                 ResultSet rs = pstmt.executeQuery()) {
 
-            // returning the model from query
-            return TableModelUtil.buildTableModel(rs);
+                // returning the model from query
+                return TableModelUtil.buildTableModel(rs);
+            }
         }
     }
 
@@ -117,6 +122,7 @@ public class LabResultDAOImpl implements LabResultDAO {
                                        result = ?,
                                        uploaded_at = ?
                               WHERE lab_result_id = ?
+                                AND COALESCE(delete_flag, FALSE) = FALSE
                 """;
 
         // validate connection
@@ -124,7 +130,7 @@ public class LabResultDAOImpl implements LabResultDAO {
         // creating PreparedStatement
         try (Connection conn = DatabaseConfig.getConnection();
              PreparedStatement pstmt = conn.prepareStatement(sql)) {
-            ensureAppointmentIdColumn(conn);
+            ensureOptionalColumns(conn);
             // inserting arguments into the query statement
             if (labResult.getConsultationId() == null) {
                 pstmt.setNull(1, Types.INTEGER);
@@ -151,13 +157,19 @@ public class LabResultDAOImpl implements LabResultDAO {
     @Override
     public void delete(Integer id) throws SQLException {
         // creating sql variable with sql statement
-        String sql = "DELETE FROM lab_results WHERE lab_result_id = ?";
+        String sql = """
+                UPDATE lab_results
+                SET delete_flag = TRUE
+                WHERE lab_result_id = ?
+                  AND COALESCE(delete_flag, FALSE) = FALSE
+                """;
 
         // validate connection
         // setting up connection with database
         // creating PreparedStatement
         try (Connection conn = DatabaseConfig.getConnection();
              PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            ensureOptionalColumns(conn);
             // inserting arguments into the query statement
             pstmt.setInt(1, id);
 
@@ -170,14 +182,14 @@ public class LabResultDAOImpl implements LabResultDAO {
     @Override
     public DefaultTableModel findByConsultationId(Integer consultationId) throws SQLException {
         // creating sql variable with sql statement
-        String sql = "SELECT * FROM lab_results WHERE consultation_id = ?";
+        String sql = "SELECT * FROM lab_results WHERE consultation_id = ? AND COALESCE(delete_flag, FALSE) = FALSE";
 
         // validate connection
         // setting up connection with database
         // creating PreparedStatement
         try (Connection conn = DatabaseConfig.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
-            ensureAppointmentIdColumn(conn);
+            ensureOptionalColumns(conn);
 
             // inserting arguments into the query statement
             ps.setInt(1, consultationId);
@@ -194,14 +206,14 @@ public class LabResultDAOImpl implements LabResultDAO {
     @Override
     public DefaultTableModel findByTechnicianId(Integer technicianId) throws SQLException {
         // creating sql variable with sql statement
-        String sql = "SELECT * FROM lab_results WHERE technician_id = ?";
+        String sql = "SELECT * FROM lab_results WHERE technician_id = ? AND COALESCE(delete_flag, FALSE) = FALSE";
 
         // validate connection
         // setting up connection with database
         // creating PreparedStatement
         try (Connection conn = DatabaseConfig.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
-            ensureAppointmentIdColumn(conn);
+            ensureOptionalColumns(conn);
 
             // inserting arguments into the query statement
             ps.setInt(1, technicianId);
@@ -260,15 +272,20 @@ public class LabResultDAOImpl implements LabResultDAO {
         return labResult;
     }
 
-    private void ensureAppointmentIdColumn(Connection conn) throws SQLException {
-        if (hasColumn(conn, "appointment_id")) {
+    private void ensureOptionalColumns(Connection conn) throws SQLException {
+        ensureColumn(conn, "appointment_id", "ALTER TABLE lab_results ADD COLUMN appointment_id INT NULL");
+        ensureColumn(conn, "delete_flag", "ALTER TABLE lab_results ADD COLUMN delete_flag BOOLEAN NOT NULL DEFAULT FALSE");
+    }
+
+    private void ensureColumn(Connection conn, String columnName, String alterSql) throws SQLException {
+        if (hasColumn(conn, columnName)) {
             return;
         }
 
         try (Statement stmt = conn.createStatement()) {
-            stmt.executeUpdate("ALTER TABLE lab_results ADD COLUMN appointment_id INT NULL");
+            stmt.executeUpdate(alterSql);
         } catch (SQLException ex) {
-            if (!hasColumn(conn, "appointment_id")) {
+            if (!hasColumn(conn, columnName)) {
                 throw ex;
             }
         }

--- a/src/main/java/ie/setu/hcs/dao/impl/MedicalRecordDAOImpl.java
+++ b/src/main/java/ie/setu/hcs/dao/impl/MedicalRecordDAOImpl.java
@@ -25,6 +25,7 @@ public class MedicalRecordDAOImpl implements MedicalRecordDAO {
         // creating PreparedStatement
         try (Connection conn = DatabaseConfig.getConnection();
             PreparedStatement pstmt = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            ensureDeleteFlagColumn(conn);
             // inserting arguments into the query statement
             pstmt.setInt(1, medicalRecord.getPatientId());
             pstmt.setInt(2, medicalRecord.getConsultationId());
@@ -48,13 +49,18 @@ public class MedicalRecordDAOImpl implements MedicalRecordDAO {
     @Override
     public MedicalRecord findById(Integer id) throws SQLException {
         // creating sql variable with sql statement
-        String sql = "SELECT * FROM medical_records WHERE record_id = ?";
+        String sql = """
+                SELECT * FROM medical_records
+                WHERE record_id = ?
+                  AND COALESCE(delete_flag, FALSE) = FALSE
+                """;
 
         // validate connection
         // setting up connection with database
         // creating PreparedStatement
         try (Connection conn = DatabaseConfig.getConnection();
             PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            ensureDeleteFlagColumn(conn);
             // inserting arguments into the query statement
             pstmt.setInt(1, id);
 
@@ -76,18 +82,20 @@ public class MedicalRecordDAOImpl implements MedicalRecordDAO {
     @Override
     public DefaultTableModel findAll() throws SQLException {
         // creating sql variable with sql statement
-        String sql = "SELECT * FROM medical_records";
+        String sql = "SELECT * FROM medical_records WHERE COALESCE(delete_flag, FALSE) = FALSE";
 
         // validate connection
         // setting up connection with database
         // creating PreparedStatement
         // executing the query
-        try (Connection conn = DatabaseConfig.getConnection();
-        PreparedStatement pstmt = conn.prepareStatement(sql);
-        ResultSet rs = pstmt.executeQuery()) {
+        try (Connection conn = DatabaseConfig.getConnection()) {
+            ensureDeleteFlagColumn(conn);
+            try (PreparedStatement pstmt = conn.prepareStatement(sql);
+                 ResultSet rs = pstmt.executeQuery()) {
 
-            // returning the model from query
-            return TableModelUtil.buildTableModel(rs);
+                // returning the model from query
+                return TableModelUtil.buildTableModel(rs);
+            }
         }
     }
 
@@ -101,6 +109,7 @@ public class MedicalRecordDAOImpl implements MedicalRecordDAO {
                                         prescription = ?,
                                         created_at = ?
                                   WHERE record_id = ?
+                                    AND COALESCE(delete_flag, FALSE) = FALSE
                 """;
 
         // validate connection
@@ -108,6 +117,7 @@ public class MedicalRecordDAOImpl implements MedicalRecordDAO {
         // creating PreparedStatement
         try (Connection conn = DatabaseConfig.getConnection();
         PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            ensureDeleteFlagColumn(conn);
             // inserting arguments into the query statement
             pstmt.setInt(1, medicalRecord.getPatientId());
             pstmt.setInt(2, medicalRecord.getConsultationId());
@@ -124,13 +134,19 @@ public class MedicalRecordDAOImpl implements MedicalRecordDAO {
     @Override
     public void delete(Integer id) throws SQLException {
         // creating sql variable with sql statement
-        String sql = "DELETE FROM medical_records WHERE record_id = ?";
+        String sql = """
+                UPDATE medical_records
+                SET delete_flag = TRUE
+                WHERE record_id = ?
+                  AND COALESCE(delete_flag, FALSE) = FALSE
+                """;
 
         // validate connection
         // setting up connection with database
         // creating PreparedStatement
         try (Connection conn = DatabaseConfig.getConnection();
              PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            ensureDeleteFlagColumn(conn);
             // inserting arguments into the query statement
             pstmt.setInt(1, id);
 
@@ -146,7 +162,7 @@ public class MedicalRecordDAOImpl implements MedicalRecordDAO {
 
         // creating sql variable with sql statement
         String sql =
-                "SELECT * FROM medical_records WHERE patient_id = ?";
+                "SELECT * FROM medical_records WHERE patient_id = ? AND COALESCE(delete_flag, FALSE) = FALSE";
 
         // validate connection
         // setting up connection with database
@@ -154,6 +170,7 @@ public class MedicalRecordDAOImpl implements MedicalRecordDAO {
         try (Connection conn = DatabaseConfig.getConnection();
              PreparedStatement ps =
                      conn.prepareStatement(sql)) {
+            ensureDeleteFlagColumn(conn);
 
             // inserting arguments into the query statement
             ps.setInt(1, patientId);
@@ -173,7 +190,7 @@ public class MedicalRecordDAOImpl implements MedicalRecordDAO {
 
         // creating sql variable with sql statement
         String sql =
-                "SELECT * FROM medical_records WHERE consultation_id = ?";
+                "SELECT * FROM medical_records WHERE consultation_id = ? AND COALESCE(delete_flag, FALSE) = FALSE";
 
         // validate connection
         // setting up connection with database
@@ -181,6 +198,7 @@ public class MedicalRecordDAOImpl implements MedicalRecordDAO {
         try (Connection conn = DatabaseConfig.getConnection();
              PreparedStatement ps =
                      conn.prepareStatement(sql)) {
+            ensureDeleteFlagColumn(conn);
 
             // inserting arguments into the query statement
             ps.setInt(1, consultationId);
@@ -229,5 +247,25 @@ public class MedicalRecordDAOImpl implements MedicalRecordDAO {
 
         // returning the medical record information
         return medicalRecord;
+    }
+
+    private void ensureDeleteFlagColumn(Connection conn) throws SQLException {
+        if (hasColumn(conn, "delete_flag")) {
+            return;
+        }
+
+        try (Statement stmt = conn.createStatement()) {
+            stmt.executeUpdate("ALTER TABLE medical_records ADD COLUMN delete_flag BOOLEAN NOT NULL DEFAULT FALSE");
+        } catch (SQLException ex) {
+            if (!hasColumn(conn, "delete_flag")) {
+                throw ex;
+            }
+        }
+    }
+
+    private boolean hasColumn(Connection conn, String columnName) throws SQLException {
+        try (ResultSet columns = conn.getMetaData().getColumns(conn.getCatalog(), null, "medical_records", columnName)) {
+            return columns.next();
+        }
     }
 }

--- a/src/main/java/ie/setu/hcs/model/Account.java
+++ b/src/main/java/ie/setu/hcs/model/Account.java
@@ -17,7 +17,6 @@ public class Account {
     private String phone;
     private String gender;
     private Boolean isActive;
-    private Boolean isAdmin;
     private LocalDateTime createdAt;
 
     // creating empty Account constructor
@@ -27,12 +26,6 @@ public class Account {
     public Account(String email, String passwordHash, Integer roleId,
                    String lastName, String firstName, String ppsn, String phone,
                    String gender, Boolean isActive, LocalDateTime createdAt) {
-        this(email, passwordHash, roleId, lastName, firstName, ppsn, phone, gender, isActive, false, createdAt);
-    }
-
-    public Account(String email, String passwordHash, Integer roleId,
-                   String lastName, String firstName, String ppsn, String phone,
-                   String gender, Boolean isActive, Boolean isAdmin, LocalDateTime createdAt) {
         // implementing attributes
         this.email = email;
         this.passwordHash = passwordHash;
@@ -43,7 +36,6 @@ public class Account {
         this.phone = phone;
         this.gender = gender;
         this.isActive = isActive;
-        this.isAdmin = isAdmin;
         this.createdAt = createdAt;
     }
 
@@ -51,12 +43,6 @@ public class Account {
     public Account(Integer accountId, String email, String passwordHash, Integer roleId,
                    String lastName, String firstName, String ppsn, String phone,
                    String gender, Boolean isActive, LocalDateTime createdAt) {
-        this(accountId, email, passwordHash, roleId, lastName, firstName, ppsn, phone, gender, isActive, false, createdAt);
-    }
-
-    public Account(Integer accountId, String email, String passwordHash, Integer roleId,
-                   String lastName, String firstName, String ppsn, String phone,
-                   String gender, Boolean isActive, Boolean isAdmin, LocalDateTime createdAt) {
         // implementing attributes
         this.accountId = accountId;
         this.email = email;
@@ -68,7 +54,6 @@ public class Account {
         this.phone = phone;
         this.gender = gender;
         this.isActive = isActive;
-        this.isAdmin = isAdmin;
         this.createdAt = createdAt;
     }
 
@@ -120,10 +105,6 @@ public class Account {
     // creating getter for isActive
     public Boolean isActive() {
         return isActive;
-    }
-
-    public Boolean isAdmin() {
-        return isAdmin;
     }
 
     // creating getter for createdAt
@@ -181,10 +162,6 @@ public class Account {
         isActive = active;
     }
 
-    public void setAdmin(Boolean admin) {
-        isAdmin = admin;
-    }
-
     // creating setter for createdAt
     public void setCreatedAt(LocalDateTime createdAt) {
         this.createdAt = createdAt;
@@ -198,7 +175,6 @@ public class Account {
                 "\nLast name: " + lastName +
                 "\nEmail: " + email +
                 "\nRole Id: " + roleId +
-                "\nActive: " + isActive +
-                "\nAdmin: " + isAdmin;
+                "\nActive: " + isActive;
     }
 }

--- a/src/main/java/ie/setu/hcs/service/AdminRegistrationService.java
+++ b/src/main/java/ie/setu/hcs/service/AdminRegistrationService.java
@@ -59,7 +59,6 @@ public class AdminRegistrationService {
                 true,
                 LocalDateTime.now()
         );
-        account.setAdmin(true);
 
         try {
             Integer depId = departmentDAO.findByName(department);

--- a/src/main/java/ie/setu/hcs/service/AdminService.java
+++ b/src/main/java/ie/setu/hcs/service/AdminService.java
@@ -41,7 +41,6 @@ public class AdminService {
     }
 
     public DefaultTableModel getAccountsForManagement() throws Exception {
-        ensureAdminColumn();
         String sql = """
                 SELECT account_id,
                        first_name,
@@ -57,8 +56,7 @@ public class AdminService {
                        ppsn,
                        phone,
                        gender,
-                       is_active,
-                       is_admin
+                       is_active
                 FROM accounts
                 ORDER BY last_name, first_name
                 """;
@@ -144,8 +142,7 @@ public class AdminService {
                        ad.job_title,
                        ad.employee_num,
                        COALESCE(dep.name, '') AS department,
-                       a.is_active,
-                       a.is_admin
+                       a.is_active
                 FROM administrators ad
                 JOIN accounts a ON ad.account_id = a.account_id
                 LEFT JOIN departments dep ON ad.dep_id = dep.dep_id
@@ -169,7 +166,7 @@ public class AdminService {
     }
 
     public void updateAccount(Integer accountId, String email, String firstName, String lastName,
-                              String ppsn, String phone, String gender, Boolean isActive, Boolean isAdmin) throws Exception {
+                              String ppsn, String phone, String gender, Boolean isActive) throws Exception {
         Account existing = requireAccount(accountId);
         String normalizedEmail = InputValidationUtil.requireEmail(email);
         String normalizedFirstName = InputValidationUtil.requireNonBlank(firstName, "First name");
@@ -182,7 +179,6 @@ public class AdminService {
         existing.setPhone(blankToNull(InputValidationUtil.optionalTrim(phone)));
         existing.setGender(blankToNull(InputValidationUtil.optionalTrim(gender)));
         existing.setActive(Boolean.TRUE.equals(isActive));
-        existing.setAdmin(Boolean.TRUE.equals(isAdmin));
         accountDAO.update(existing);
     }
 
@@ -297,28 +293,6 @@ public class AdminService {
              PreparedStatement ps = conn.prepareStatement(sql);
              ResultSet rs = ps.executeQuery()) {
             return TableModelUtil.buildTableModel(rs);
-        }
-    }
-
-    private void ensureAdminColumn() throws Exception {
-        try (Connection conn = DatabaseConfig.getConnection();
-             ResultSet columns = conn.getMetaData().getColumns(conn.getCatalog(), null, "accounts", "is_admin")) {
-            if (columns.next()) {
-                return;
-            }
-        }
-
-        try (Connection conn = DatabaseConfig.getConnection();
-             PreparedStatement ps = conn.prepareStatement("ALTER TABLE accounts ADD COLUMN is_admin BOOLEAN NOT NULL DEFAULT FALSE")) {
-            ps.executeUpdate();
-        } catch (Exception ex) {
-            try (Connection conn = DatabaseConfig.getConnection();
-                 ResultSet columns = conn.getMetaData().getColumns(conn.getCatalog(), null, "accounts", "is_admin")) {
-                if (columns.next()) {
-                    return;
-                }
-            }
-            throw ex;
         }
     }
 

--- a/src/main/java/ie/setu/hcs/service/AppointmentService.java
+++ b/src/main/java/ie/setu/hcs/service/AppointmentService.java
@@ -53,6 +53,7 @@ public class AppointmentService {
                 JOIN doctors d ON ap.doctor_id = d.doctor_id
                 JOIN accounts da ON d.account_id = da.account_id
                 WHERE ap.patient_id = ?
+                  AND COALESCE(ap.delete_flag, FALSE) = FALSE
                 ORDER BY ap.appointment_datetime DESC
                 """;
         return displayAppointments(sql, patient.getPatientId());
@@ -87,6 +88,7 @@ public class AppointmentService {
                 JOIN patients p ON ap.patient_id = p.patient_id
                 JOIN accounts pa ON p.account_id = pa.account_id
                 WHERE ap.doctor_id = ?
+                  AND COALESCE(ap.delete_flag, FALSE) = FALSE
                 ORDER BY ap.appointment_datetime DESC
                 """;
         return displayAppointments(sql, doctor.getDoctorId());
@@ -106,6 +108,7 @@ public class AppointmentService {
                 JOIN accounts pa ON p.account_id = pa.account_id
                 JOIN doctors d ON ap.doctor_id = d.doctor_id
                 JOIN accounts da ON d.account_id = da.account_id
+                WHERE COALESCE(ap.delete_flag, FALSE) = FALSE
                 ORDER BY ap.appointment_datetime DESC
                 """;
 
@@ -134,6 +137,7 @@ public class AppointmentService {
                 JOIN accounts a ON p.account_id = a.account_id
                 JOIN appointments ap ON p.patient_id = ap.patient_id
                 WHERE ap.doctor_id = ?
+                  AND COALESCE(ap.delete_flag, FALSE) = FALSE
                 ORDER BY a.last_name, a.first_name
                 """;
 
@@ -520,6 +524,7 @@ public class AppointmentService {
     private void ensureAppointmentColumns(Connection conn) throws Exception {
         ensureMedicalNeedColumn(conn);
         ensureConsultationRoomColumn(conn);
+        ensureDeleteFlagColumn(conn);
     }
 
     private void ensureMedicalNeedColumn(Connection conn) throws Exception {
@@ -550,6 +555,20 @@ public class AppointmentService {
         }
     }
 
+    private void ensureDeleteFlagColumn(Connection conn) throws Exception {
+        if (hasColumn(conn, "delete_flag")) {
+            return;
+        }
+
+        try (Statement stmt = conn.createStatement()) {
+            stmt.executeUpdate("ALTER TABLE appointments ADD COLUMN delete_flag BOOLEAN NOT NULL DEFAULT FALSE");
+        } catch (Exception ex) {
+            if (!hasColumn(conn, "delete_flag")) {
+                throw ex;
+            }
+        }
+    }
+
     private String normalizeRoom(String consultationRoom) {
         return consultationRoom == null ? "" : consultationRoom.trim();
     }
@@ -575,7 +594,7 @@ public class AppointmentService {
 
     private boolean canOverridePendingRestriction(Account actor) {
         return actor != null
-                && (Boolean.TRUE.equals(actor.isAdmin()) || Integer.valueOf(4).equals(actor.getRoleId()));
+                && Integer.valueOf(4).equals(actor.getRoleId());
     }
 
     private boolean hasColumn(Connection conn, String columnName) throws Exception {

--- a/src/main/java/ie/setu/hcs/service/ConsultationService.java
+++ b/src/main/java/ie/setu/hcs/service/ConsultationService.java
@@ -62,11 +62,13 @@ public class ConsultationService {
                 FROM consultation c
                 JOIN appointments a ON c.appointment_id = a.appointment_id
                 WHERE a.patient_id = ?
+                  AND COALESCE(c.delete_flag, FALSE) = FALSE
+                  AND COALESCE(a.delete_flag, FALSE) = FALSE
                 ORDER BY c.created_at DESC
                 """.formatted(appointmentDisplaySql());
 
         try (Connection conn = DatabaseConfig.getConnection();
-             PreparedStatement ps = conn.prepareStatement(sql)) {
+             PreparedStatement ps = prepareConsultationQuery(conn, sql)) {
             ps.setInt(1, patient.getPatientId());
             try (ResultSet rs = ps.executeQuery()) {
                 return TableModelUtil.buildTableModel(rs);
@@ -89,11 +91,13 @@ public class ConsultationService {
                 JOIN patients p ON a.patient_id = p.patient_id
                 JOIN accounts pa ON p.account_id = pa.account_id
                 WHERE a.doctor_id = ?
+                  AND COALESCE(c.delete_flag, FALSE) = FALSE
+                  AND COALESCE(a.delete_flag, FALSE) = FALSE
                 ORDER BY c.created_at DESC
                 """.formatted(appointmentDisplaySql());
 
         try (Connection conn = DatabaseConfig.getConnection();
-             PreparedStatement ps = conn.prepareStatement(sql)) {
+             PreparedStatement ps = prepareConsultationQuery(conn, sql)) {
             ps.setInt(1, doctor.getDoctorId());
             try (ResultSet rs = ps.executeQuery()) {
                 return TableModelUtil.buildTableModel(rs);
@@ -117,11 +121,13 @@ public class ConsultationService {
                 JOIN accounts pa ON p.account_id = pa.account_id
                 JOIN doctors d ON a.doctor_id = d.doctor_id
                 JOIN accounts da ON d.account_id = da.account_id
+                WHERE COALESCE(c.delete_flag, FALSE) = FALSE
+                  AND COALESCE(a.delete_flag, FALSE) = FALSE
                 ORDER BY c.created_at DESC
                 """.formatted(appointmentDisplaySql());
 
         try (Connection conn = DatabaseConfig.getConnection();
-             PreparedStatement ps = conn.prepareStatement(sql);
+             PreparedStatement ps = prepareConsultationQuery(conn, sql);
              ResultSet rs = ps.executeQuery()) {
             return TableModelUtil.buildTableModel(rs);
         }
@@ -138,6 +144,7 @@ public class ConsultationService {
                 JOIN patients p ON ap.patient_id = p.patient_id
                 JOIN accounts pa ON p.account_id = pa.account_id
                 WHERE ap.doctor_id = ?
+                  AND COALESCE(ap.delete_flag, FALSE) = FALSE
                 ORDER BY ap.appointment_datetime DESC
                 """;
         return appointmentOptionsFromTable(loadAppointmentOptions(sql, doctor.getDoctorId()));
@@ -155,6 +162,7 @@ public class ConsultationService {
                 JOIN accounts pa ON p.account_id = pa.account_id
                 JOIN doctors d ON ap.doctor_id = d.doctor_id
                 JOIN accounts da ON d.account_id = da.account_id
+                WHERE COALESCE(ap.delete_flag, FALSE) = FALSE
                 ORDER BY ap.appointment_datetime DESC
                 """;
         return appointmentOptionsFromTable(loadAppointmentOptions(sql, null));
@@ -180,6 +188,7 @@ public class ConsultationService {
         LocalDateTime now = LocalDateTime.now();
 
         return TransactionRunner.inTransaction(conn -> {
+            ensureSoftDeleteColumns(conn);
             Consultation existing = findConsultationByAppointmentId(conn, appointmentId);
             Integer consultationId;
 
@@ -226,6 +235,7 @@ public class ConsultationService {
         }
 
         TransactionRunner.inTransaction(conn -> {
+            ensureSoftDeleteColumns(conn);
             deleteByConsultationId(conn, "lab_results", "consultation_id", consultationId);
             deleteByConsultationId(conn, "invoices", "consultation_id", consultationId);
             deleteByConsultationId(conn, "medical_records", "consultation_id", consultationId);
@@ -412,7 +422,7 @@ public class ConsultationService {
 
     private DefaultTableModel loadAppointmentOptions(String sql, Integer doctorId) throws Exception {
         try (Connection conn = DatabaseConfig.getConnection();
-             PreparedStatement ps = conn.prepareStatement(sql)) {
+             PreparedStatement ps = prepareConsultationQuery(conn, sql)) {
             if (doctorId != null) {
                 ps.setInt(1, doctorId);
             }
@@ -435,7 +445,11 @@ public class ConsultationService {
     }
 
     private Consultation findConsultationByAppointmentId(Connection conn, Integer appointmentId) throws SQLException {
-        String sql = "SELECT * FROM consultation WHERE appointment_id = ?";
+        String sql = """
+                SELECT * FROM consultation
+                WHERE appointment_id = ?
+                  AND COALESCE(delete_flag, FALSE) = FALSE
+                """;
         try (PreparedStatement ps = conn.prepareStatement(sql)) {
             ps.setInt(1, appointmentId);
             try (ResultSet rs = ps.executeQuery()) {
@@ -486,7 +500,12 @@ public class ConsultationService {
     }
 
     private void deleteConsultation(Connection conn, Integer consultationId) throws SQLException {
-        String sql = "DELETE FROM consultation WHERE consultation_id = ?";
+        String sql = """
+                UPDATE consultation
+                SET delete_flag = TRUE
+                WHERE consultation_id = ?
+                  AND COALESCE(delete_flag, FALSE) = FALSE
+                """;
         try (PreparedStatement ps = conn.prepareStatement(sql)) {
             ps.setInt(1, consultationId);
             ps.executeUpdate();
@@ -494,7 +513,12 @@ public class ConsultationService {
     }
 
     private MedicalRecord findMedicalRecordByConsultationId(Connection conn, Integer consultationId) throws SQLException {
-        String sql = "SELECT * FROM medical_records WHERE consultation_id = ? LIMIT 1";
+        String sql = """
+                SELECT * FROM medical_records
+                WHERE consultation_id = ?
+                  AND COALESCE(delete_flag, FALSE) = FALSE
+                LIMIT 1
+                """;
         try (PreparedStatement ps = conn.prepareStatement(sql)) {
             ps.setInt(1, consultationId);
             try (ResultSet rs = ps.executeQuery()) {
@@ -539,7 +563,12 @@ public class ConsultationService {
     }
 
     private Invoice findInvoiceByConsultationId(Connection conn, Integer consultationId) throws SQLException {
-        String sql = "SELECT * FROM invoices WHERE consultation_id = ? LIMIT 1";
+        String sql = """
+                SELECT * FROM invoices
+                WHERE consultation_id = ?
+                  AND COALESCE(delete_flag, FALSE) = FALSE
+                LIMIT 1
+                """;
         try (PreparedStatement ps = conn.prepareStatement(sql)) {
             ps.setInt(1, consultationId);
             try (ResultSet rs = ps.executeQuery()) {
@@ -597,10 +626,49 @@ public class ConsultationService {
     }
 
     private void deleteByConsultationId(Connection conn, String tableName, String columnName, Integer consultationId) throws SQLException {
-        String sql = "DELETE FROM " + tableName + " WHERE " + columnName + " = ?";
+        String sql = "UPDATE " + tableName + " SET delete_flag = TRUE WHERE " + columnName
+                + " = ? AND COALESCE(delete_flag, FALSE) = FALSE";
         try (PreparedStatement ps = conn.prepareStatement(sql)) {
             ps.setInt(1, consultationId);
             ps.executeUpdate();
+        }
+    }
+
+    private PreparedStatement prepareConsultationQuery(Connection conn, String sql) throws SQLException {
+        ensureSoftDeleteColumns(conn);
+        return conn.prepareStatement(sql);
+    }
+
+    private void ensureSoftDeleteColumns(Connection conn) throws SQLException {
+        ensureColumn(conn, "appointments", "delete_flag",
+                "ALTER TABLE appointments ADD COLUMN delete_flag BOOLEAN NOT NULL DEFAULT FALSE");
+        ensureColumn(conn, "consultation", "delete_flag",
+                "ALTER TABLE consultation ADD COLUMN delete_flag BOOLEAN NOT NULL DEFAULT FALSE");
+        ensureColumn(conn, "medical_records", "delete_flag",
+                "ALTER TABLE medical_records ADD COLUMN delete_flag BOOLEAN NOT NULL DEFAULT FALSE");
+        ensureColumn(conn, "invoices", "delete_flag",
+                "ALTER TABLE invoices ADD COLUMN delete_flag BOOLEAN NOT NULL DEFAULT FALSE");
+        ensureColumn(conn, "lab_results", "delete_flag",
+                "ALTER TABLE lab_results ADD COLUMN delete_flag BOOLEAN NOT NULL DEFAULT FALSE");
+    }
+
+    private void ensureColumn(Connection conn, String tableName, String columnName, String alterSql) throws SQLException {
+        if (hasColumn(conn, tableName, columnName)) {
+            return;
+        }
+
+        try (Statement stmt = conn.createStatement()) {
+            stmt.executeUpdate(alterSql);
+        } catch (SQLException ex) {
+            if (!hasColumn(conn, tableName, columnName)) {
+                throw ex;
+            }
+        }
+    }
+
+    private boolean hasColumn(Connection conn, String tableName, String columnName) throws SQLException {
+        try (ResultSet columns = conn.getMetaData().getColumns(conn.getCatalog(), null, tableName, columnName)) {
+            return columns.next();
         }
     }
 

--- a/src/main/java/ie/setu/hcs/service/DoctorRegistrationService.java
+++ b/src/main/java/ie/setu/hcs/service/DoctorRegistrationService.java
@@ -72,7 +72,6 @@ public class DoctorRegistrationService {
                 true,
                 LocalDateTime.now()
         );
-        account.setAdmin(false);
         
         try {
             // getting ids

--- a/src/main/java/ie/setu/hcs/service/InsuranceService.java
+++ b/src/main/java/ie/setu/hcs/service/InsuranceService.java
@@ -42,6 +42,7 @@ public class InsuranceService {
                        i.expiration_date
                 FROM insurance i
                 WHERE i.patient_id = ?
+                  AND COALESCE(i.delete_flag, FALSE) = FALSE
                 ORDER BY i.expiration_date DESC
                 """;
         return displayInsurance(sql, patient.getPatientId());
@@ -58,11 +59,12 @@ public class InsuranceService {
                 FROM insurance i
                 JOIN patients p ON i.patient_id = p.patient_id
                 JOIN accounts a ON p.account_id = a.account_id
+                WHERE COALESCE(i.delete_flag, FALSE) = FALSE
                 ORDER BY i.expiration_date DESC
                 """;
 
         try (Connection conn = DatabaseConfig.getConnection();
-             PreparedStatement ps = conn.prepareStatement(sql);
+             PreparedStatement ps = prepareInsuranceQuery(conn, sql);
              ResultSet rs = ps.executeQuery()) {
             return TableModelUtil.buildTableModel(rs);
         }
@@ -282,7 +284,7 @@ public class InsuranceService {
 
     private boolean canOverridePendingRestriction(Account actor) {
         return actor != null
-                && (Boolean.TRUE.equals(actor.isAdmin()) || Integer.valueOf(4).equals(actor.getRoleId()));
+                && Integer.valueOf(4).equals(actor.getRoleId());
     }
 
     private Insurance requireInsurance(Integer insuranceId) throws Exception {
@@ -298,11 +300,36 @@ public class InsuranceService {
 
     private DefaultTableModel displayInsurance(String sql, Integer patientId) throws Exception {
         try (Connection conn = DatabaseConfig.getConnection();
-             PreparedStatement ps = conn.prepareStatement(sql)) {
+             PreparedStatement ps = prepareInsuranceQuery(conn, sql)) {
             ps.setInt(1, patientId);
             try (ResultSet rs = ps.executeQuery()) {
                 return TableModelUtil.buildTableModel(rs);
             }
+        }
+    }
+
+    private PreparedStatement prepareInsuranceQuery(Connection conn, String sql) throws Exception {
+        ensureDeleteFlagColumn(conn);
+        return conn.prepareStatement(sql);
+    }
+
+    private void ensureDeleteFlagColumn(Connection conn) throws Exception {
+        if (hasColumn(conn, "delete_flag")) {
+            return;
+        }
+
+        try (var stmt = conn.createStatement()) {
+            stmt.executeUpdate("ALTER TABLE insurance ADD COLUMN delete_flag BOOLEAN NOT NULL DEFAULT FALSE");
+        } catch (Exception ex) {
+            if (!hasColumn(conn, "delete_flag")) {
+                throw ex;
+            }
+        }
+    }
+
+    private boolean hasColumn(Connection conn, String columnName) throws Exception {
+        try (ResultSet columns = conn.getMetaData().getColumns(conn.getCatalog(), null, "insurance", columnName)) {
+            return columns.next();
         }
     }
 }

--- a/src/main/java/ie/setu/hcs/service/InvoiceService.java
+++ b/src/main/java/ie/setu/hcs/service/InvoiceService.java
@@ -35,7 +35,9 @@ public class InvoiceService {
                        i.paid_at
                 FROM invoices i
                 LEFT JOIN consultation c ON i.consultation_id = c.consultation_id
+                    AND COALESCE(c.delete_flag, FALSE) = FALSE
                 WHERE i.patient_id = ?
+                  AND COALESCE(i.delete_flag, FALSE) = FALSE
                 ORDER BY i.issued_at DESC
                 """.formatted(consultationDisplaySql());
         return displayInvoices(sql, patient.getPatientId());
@@ -53,8 +55,10 @@ public class InvoiceService {
                        i.paid_at
                 FROM invoices i
                 LEFT JOIN consultation c ON i.consultation_id = c.consultation_id
+                    AND COALESCE(c.delete_flag, FALSE) = FALSE
                 WHERE i.patient_id = ?
                   AND i.invoice_status != 'PAID'
+                  AND COALESCE(i.delete_flag, FALSE) = FALSE
                 ORDER BY i.issued_at DESC
                 """.formatted(consultationDisplaySql());
         return displayInvoices(sql, patient.getPatientId());
@@ -74,11 +78,13 @@ public class InvoiceService {
                 JOIN patients p ON i.patient_id = p.patient_id
                 JOIN accounts a ON p.account_id = a.account_id
                 LEFT JOIN consultation c ON i.consultation_id = c.consultation_id
+                    AND COALESCE(c.delete_flag, FALSE) = FALSE
+                WHERE COALESCE(i.delete_flag, FALSE) = FALSE
                 ORDER BY i.issued_at DESC
                 """.formatted(consultationDisplaySql());
 
         try (Connection conn = DatabaseConfig.getConnection();
-             PreparedStatement ps = conn.prepareStatement(sql);
+             PreparedStatement ps = prepareInvoiceQuery(conn, sql);
              ResultSet rs = ps.executeQuery()) {
             return TableModelUtil.buildTableModel(rs);
         }
@@ -118,7 +124,7 @@ public class InvoiceService {
 
     private DefaultTableModel displayInvoices(String sql, Integer patientId) throws Exception {
         try (Connection conn = DatabaseConfig.getConnection();
-             PreparedStatement ps = conn.prepareStatement(sql)) {
+             PreparedStatement ps = prepareInvoiceQuery(conn, sql)) {
             ps.setInt(1, patientId);
             try (ResultSet rs = ps.executeQuery()) {
                 return TableModelUtil.buildTableModel(rs);
@@ -153,5 +159,31 @@ public class InvoiceService {
                     ELSE CONCAT('Consultation #', i.consultation_id, ' | ', c.diagnosis)
                 END
                 """;
+    }
+
+    private PreparedStatement prepareInvoiceQuery(Connection conn, String sql) throws Exception {
+        ensureDeleteFlagColumn(conn, "invoices");
+        ensureDeleteFlagColumn(conn, "consultation");
+        return conn.prepareStatement(sql);
+    }
+
+    private void ensureDeleteFlagColumn(Connection conn, String tableName) throws Exception {
+        if (hasColumn(conn, tableName, "delete_flag")) {
+            return;
+        }
+
+        try (var stmt = conn.createStatement()) {
+            stmt.executeUpdate("ALTER TABLE " + tableName + " ADD COLUMN delete_flag BOOLEAN NOT NULL DEFAULT FALSE");
+        } catch (Exception ex) {
+            if (!hasColumn(conn, tableName, "delete_flag")) {
+                throw ex;
+            }
+        }
+    }
+
+    private boolean hasColumn(Connection conn, String tableName, String columnName) throws Exception {
+        try (ResultSet columns = conn.getMetaData().getColumns(conn.getCatalog(), null, tableName, columnName)) {
+            return columns.next();
+        }
     }
 }

--- a/src/main/java/ie/setu/hcs/service/LabService.java
+++ b/src/main/java/ie/setu/hcs/service/LabService.java
@@ -59,6 +59,7 @@ public class LabService {
                 LEFT JOIN lab_technicians t ON lr.technician_id = t.technician_id
                 LEFT JOIN accounts ta ON t.account_id = ta.account_id
                 WHERE a.patient_id = ?
+                  AND COALESCE(lr.delete_flag, FALSE) = FALSE
                 ORDER BY lr.uploaded_at DESC
                 """;
 
@@ -86,6 +87,7 @@ public class LabService {
                 LEFT JOIN consultation c ON lr.consultation_id = c.consultation_id
                 JOIN appointments a ON COALESCE(lr.appointment_id, c.appointment_id) = a.appointment_id
                 WHERE lr.technician_id = ?
+                  AND COALESCE(lr.delete_flag, FALSE) = FALSE
                 ORDER BY lr.uploaded_at DESC
                 """;
 
@@ -119,6 +121,7 @@ public class LabService {
                 LEFT JOIN lab_technicians t ON lr.technician_id = t.technician_id
                 LEFT JOIN accounts ta ON t.account_id = ta.account_id
                 WHERE a.doctor_id = ?
+                  AND COALESCE(lr.delete_flag, FALSE) = FALSE
                 ORDER BY lr.uploaded_at DESC
                 """;
 
@@ -150,6 +153,7 @@ public class LabService {
                 JOIN accounts pa ON p.account_id = pa.account_id
                 LEFT JOIN lab_technicians t ON lr.technician_id = t.technician_id
                 LEFT JOIN accounts ta ON t.account_id = ta.account_id
+                WHERE COALESCE(lr.delete_flag, FALSE) = FALSE
                 ORDER BY lr.uploaded_at DESC
                 """;
 
@@ -258,6 +262,8 @@ public class LabService {
                 JOIN appointments a ON c.appointment_id = a.appointment_id
                 JOIN patients p ON a.patient_id = p.patient_id
                 JOIN accounts pa ON p.account_id = pa.account_id
+                WHERE COALESCE(c.delete_flag, FALSE) = FALSE
+                  AND COALESCE(a.delete_flag, FALSE) = FALSE
                 ORDER BY c.created_at DESC
                 """;
         DefaultTableModel consultations;
@@ -304,6 +310,7 @@ public class LabService {
                 LEFT JOIN consultation c ON c.appointment_id = a.appointment_id
                 WHERE c.consultation_id IS NULL
                   AND LOWER(a.status) NOT IN ('cancelled', 'rejected')
+                  AND COALESCE(a.delete_flag, FALSE) = FALSE
                 ORDER BY a.appointment_datetime DESC
                 """;
         DefaultTableModel appointments;
@@ -415,6 +422,9 @@ public class LabService {
     private void ensureLabSchema(Connection conn) throws SQLException {
         ensureAppointmentIdColumn(conn);
         ensureConsultationIdNullable(conn);
+        ensureDeleteFlagColumn(conn, "lab_results");
+        ensureDeleteFlagColumn(conn, "appointments");
+        ensureDeleteFlagColumn(conn, "consultation");
     }
 
     private void ensureAppointmentIdColumn(Connection conn) throws SQLException {
@@ -454,8 +464,26 @@ public class LabService {
         }
     }
 
+    private void ensureDeleteFlagColumn(Connection conn, String tableName) throws SQLException {
+        if (hasColumn(conn, tableName, "delete_flag")) {
+            return;
+        }
+
+        try (Statement stmt = conn.createStatement()) {
+            stmt.executeUpdate("ALTER TABLE " + tableName + " ADD COLUMN delete_flag BOOLEAN NOT NULL DEFAULT FALSE");
+        } catch (SQLException ex) {
+            if (!hasColumn(conn, tableName, "delete_flag")) {
+                throw ex;
+            }
+        }
+    }
+
     private boolean hasColumn(Connection conn, String columnName) throws SQLException {
-        try (ResultSet columns = conn.getMetaData().getColumns(conn.getCatalog(), null, "lab_results", columnName)) {
+        return hasColumn(conn, "lab_results", columnName);
+    }
+
+    private boolean hasColumn(Connection conn, String tableName, String columnName) throws SQLException {
+        try (ResultSet columns = conn.getMetaData().getColumns(conn.getCatalog(), null, tableName, columnName)) {
             return columns.next();
         }
     }

--- a/src/main/java/ie/setu/hcs/service/LabTechnicianRegistrationService.java
+++ b/src/main/java/ie/setu/hcs/service/LabTechnicianRegistrationService.java
@@ -57,7 +57,6 @@ public class LabTechnicianRegistrationService {
                 true,
                 LocalDateTime.now()
         );
-        account.setAdmin(false);
 
         try {
             LabTechnician technician = new LabTechnician(

--- a/src/main/java/ie/setu/hcs/service/MedicalRecordService.java
+++ b/src/main/java/ie/setu/hcs/service/MedicalRecordService.java
@@ -37,6 +37,8 @@ public class MedicalRecordService {
                 FROM medical_records mr
                 JOIN consultation c ON mr.consultation_id = c.consultation_id
                 WHERE mr.patient_id = ?
+                  AND COALESCE(mr.delete_flag, FALSE) = FALSE
+                  AND COALESCE(c.delete_flag, FALSE) = FALSE
                 ORDER BY mr.created_at DESC
                 """;
         return loadRecords(sql, patient.getPatientId());
@@ -56,6 +58,8 @@ public class MedicalRecordService {
                 JOIN consultation c ON mr.consultation_id = c.consultation_id
                 LEFT JOIN patients p ON mr.patient_id = p.patient_id
                 LEFT JOIN accounts a ON p.account_id = a.account_id
+                WHERE COALESCE(mr.delete_flag, FALSE) = FALSE
+                  AND COALESCE(c.delete_flag, FALSE) = FALSE
                 ORDER BY mr.created_at DESC
                 """;
         return loadRecords(sql, null);
@@ -78,6 +82,9 @@ public class MedicalRecordService {
                 LEFT JOIN patients p ON mr.patient_id = p.patient_id
                 LEFT JOIN accounts a ON p.account_id = a.account_id
                 WHERE ap.doctor_id = ?
+                  AND COALESCE(mr.delete_flag, FALSE) = FALSE
+                  AND COALESCE(c.delete_flag, FALSE) = FALSE
+                  AND COALESCE(ap.delete_flag, FALSE) = FALSE
                 ORDER BY mr.created_at DESC
                 """;
 
@@ -119,13 +126,40 @@ public class MedicalRecordService {
 
     private DefaultTableModel loadRecords(String sql, Integer parameter) throws Exception {
         try (Connection conn = DatabaseConfig.getConnection();
-             PreparedStatement ps = conn.prepareStatement(sql)) {
+             PreparedStatement ps = prepareRecordsQuery(conn, sql)) {
             if (parameter != null) {
                 ps.setInt(1, parameter);
             }
             try (ResultSet rs = ps.executeQuery()) {
                 return TableModelUtil.buildTableModel(rs);
             }
+        }
+    }
+
+    private PreparedStatement prepareRecordsQuery(Connection conn, String sql) throws Exception {
+        ensureDeleteFlagColumn(conn, "medical_records");
+        ensureDeleteFlagColumn(conn, "consultation");
+        ensureDeleteFlagColumn(conn, "appointments");
+        return conn.prepareStatement(sql);
+    }
+
+    private void ensureDeleteFlagColumn(Connection conn, String tableName) throws Exception {
+        if (hasColumn(conn, tableName, "delete_flag")) {
+            return;
+        }
+
+        try (var stmt = conn.createStatement()) {
+            stmt.executeUpdate("ALTER TABLE " + tableName + " ADD COLUMN delete_flag BOOLEAN NOT NULL DEFAULT FALSE");
+        } catch (Exception ex) {
+            if (!hasColumn(conn, tableName, "delete_flag")) {
+                throw ex;
+            }
+        }
+    }
+
+    private boolean hasColumn(Connection conn, String tableName, String columnName) throws Exception {
+        try (ResultSet columns = conn.getMetaData().getColumns(conn.getCatalog(), null, tableName, columnName)) {
+            return columns.next();
         }
     }
 }

--- a/src/main/java/ie/setu/hcs/service/PatientRegistrationService.java
+++ b/src/main/java/ie/setu/hcs/service/PatientRegistrationService.java
@@ -68,7 +68,6 @@ public class PatientRegistrationService {
                 true,
                 LocalDateTime.now()
         );
-        account.setAdmin(false);
 
         try {
             Patient patient = new Patient(

--- a/src/main/java/ie/setu/hcs/ui/AdminAccountsFrame.java
+++ b/src/main/java/ie/setu/hcs/ui/AdminAccountsFrame.java
@@ -23,7 +23,6 @@ public class AdminAccountsFrame extends JFrame {
     private final JTextField txtGender = new JTextField();
     private final JTextField txtRole = new JTextField();
     private final JCheckBox chkActive = new JCheckBox("Active");
-    private final JCheckBox chkAdmin = new JCheckBox("Admin");
 
     public AdminAccountsFrame(Account adminAccount) {
         this.adminAccount = adminAccount;
@@ -117,9 +116,7 @@ public class AdminAccountsFrame extends JFrame {
         JPanel panel = new JPanel(new FlowLayout(FlowLayout.LEFT, 12, 0));
         panel.setOpaque(false);
         chkActive.setOpaque(false);
-        chkAdmin.setOpaque(false);
         panel.add(chkActive);
-        panel.add(chkAdmin);
         return panel;
     }
 
@@ -147,7 +144,6 @@ public class AdminAccountsFrame extends JFrame {
             txtGender.setText(account.getGender() == null ? "" : account.getGender());
             txtRole.setText(roleLabel(account));
             chkActive.setSelected(Boolean.TRUE.equals(account.isActive()));
-            chkAdmin.setSelected(Boolean.TRUE.equals(account.isAdmin()));
         } catch (Exception ex) {
             UIHelper.showError(this, ex);
         }
@@ -163,8 +159,7 @@ public class AdminAccountsFrame extends JFrame {
                     txtPpsn.getText(),
                     txtPhone.getText(),
                     txtGender.getText(),
-                    chkActive.isSelected(),
-                    chkAdmin.isSelected()
+                    chkActive.isSelected()
             );
             loadTable();
             JOptionPane.showMessageDialog(this, "Account updated.", "Success", JOptionPane.INFORMATION_MESSAGE);
@@ -183,16 +178,12 @@ public class AdminAccountsFrame extends JFrame {
     }
 
     private String roleLabel(Account account) {
-        String baseRole = switch (account.getRoleId()) {
+        return switch (account.getRoleId()) {
             case 1 -> "Patient";
             case 2 -> "Doctor";
             case 3 -> "Lab Technician";
             case 4 -> "Administrator";
             default -> "Role " + account.getRoleId();
         };
-        if (Boolean.TRUE.equals(account.isAdmin()) && !Integer.valueOf(4).equals(account.getRoleId())) {
-            return baseRole + " (Admin Access)";
-        }
-        return baseRole;
     }
 }

--- a/src/main/java/ie/setu/hcs/ui/AdminAdministratorsFrame.java
+++ b/src/main/java/ie/setu/hcs/ui/AdminAdministratorsFrame.java
@@ -85,8 +85,6 @@ public class AdminAdministratorsFrame extends JFrame {
         JPanel buttons = UIHelper.actionBar();
         JButton update = UIHelper.actionButton("Update", HCS_Colors.BUTTON_BLUE);
         update.addActionListener(e -> updateAdministrator());
-        JButton delete = UIHelper.actionButton("Delete", HCS_Colors.ACCENT_RED);
-        delete.addActionListener(e -> deleteAdministrator());
         JButton refresh = UIHelper.actionButton("Refresh", HCS_Colors.BUTTON_BLUE);
         refresh.addActionListener(e -> loadTable());
         JButton view = UIHelper.detailsButton(this, table, "Administrator Details");
@@ -94,7 +92,6 @@ public class AdminAdministratorsFrame extends JFrame {
         close.addActionListener(e -> AppNavigator.replace(this, new AdminDashboard(adminAccount)));
 
         buttons.add(update);
-        buttons.add(delete);
         buttons.add(refresh);
         buttons.add(view);
         buttons.add(close);
@@ -161,12 +158,4 @@ public class AdminAdministratorsFrame extends JFrame {
         }
     }
 
-    private void deleteAdministrator() {
-        try {
-            service.deleteAdministrator(UIHelper.selectedId(table, "admin_id"));
-            loadTable();
-        } catch (Exception ex) {
-            UIHelper.showError(this, ex);
-        }
-    }
 }

--- a/src/main/java/ie/setu/hcs/ui/AdminDoctorsFrame.java
+++ b/src/main/java/ie/setu/hcs/ui/AdminDoctorsFrame.java
@@ -94,8 +94,6 @@ public class AdminDoctorsFrame extends JFrame {
         JPanel buttons = UIHelper.actionBar();
         JButton update = UIHelper.actionButton("Update", HCS_Colors.BUTTON_BLUE);
         update.addActionListener(e -> updateDoctor());
-        JButton delete = UIHelper.actionButton("Delete", HCS_Colors.ACCENT_RED);
-        delete.addActionListener(e -> deleteDoctor());
         JButton refresh = UIHelper.actionButton("Refresh", HCS_Colors.BUTTON_BLUE);
         refresh.addActionListener(e -> loadTable());
         JButton view = UIHelper.detailsButton(this, table, "Doctor Details");
@@ -103,7 +101,6 @@ public class AdminDoctorsFrame extends JFrame {
         close.addActionListener(e -> AppNavigator.replace(this, new AdminDashboard(adminAccount)));
 
         buttons.add(update);
-        buttons.add(delete);
         buttons.add(refresh);
         buttons.add(view);
         buttons.add(close);
@@ -160,15 +157,6 @@ public class AdminDoctorsFrame extends JFrame {
             );
             loadTable();
             JOptionPane.showMessageDialog(this, "Doctor updated.", "Success", JOptionPane.INFORMATION_MESSAGE);
-        } catch (Exception ex) {
-            UIHelper.showError(this, ex);
-        }
-    }
-
-    private void deleteDoctor() {
-        try {
-            service.deleteDoctor(UIHelper.selectedId(table, "doctor_id"));
-            loadTable();
         } catch (Exception ex) {
             UIHelper.showError(this, ex);
         }

--- a/src/main/java/ie/setu/hcs/ui/AdminLabTechniciansFrame.java
+++ b/src/main/java/ie/setu/hcs/ui/AdminLabTechniciansFrame.java
@@ -100,8 +100,6 @@ public class AdminLabTechniciansFrame extends JFrame {
         JPanel buttons = UIHelper.actionBar();
         JButton update = UIHelper.actionButton("Update", HCS_Colors.BUTTON_BLUE);
         update.addActionListener(e -> updateTechnician());
-        JButton delete = UIHelper.actionButton("Delete", HCS_Colors.ACCENT_RED);
-        delete.addActionListener(e -> deleteTechnician());
         JButton refresh = UIHelper.actionButton("Refresh", HCS_Colors.BUTTON_BLUE);
         refresh.addActionListener(e -> loadTable());
         JButton view = UIHelper.detailsButton(this, table, "Lab Technician Details");
@@ -109,7 +107,6 @@ public class AdminLabTechniciansFrame extends JFrame {
         close.addActionListener(e -> AppNavigator.replace(this, new AdminDashboard(adminAccount)));
 
         buttons.add(update);
-        buttons.add(delete);
         buttons.add(refresh);
         buttons.add(view);
         buttons.add(close);
@@ -164,12 +161,4 @@ public class AdminLabTechniciansFrame extends JFrame {
         }
     }
 
-    private void deleteTechnician() {
-        try {
-            service.deleteTechnician(UIHelper.selectedId(table, "technician_id"));
-            loadTable();
-        } catch (Exception ex) {
-            UIHelper.showError(this, ex);
-        }
-    }
 }

--- a/src/main/java/ie/setu/hcs/ui/AdminPatientsFrame.java
+++ b/src/main/java/ie/setu/hcs/ui/AdminPatientsFrame.java
@@ -90,8 +90,6 @@ public class AdminPatientsFrame extends JFrame {
         JPanel buttons = UIHelper.actionBar();
         JButton update = UIHelper.actionButton("Update", HCS_Colors.BUTTON_BLUE);
         update.addActionListener(e -> updatePatient());
-        JButton delete = UIHelper.actionButton("Delete", HCS_Colors.ACCENT_RED);
-        delete.addActionListener(e -> deletePatient());
         JButton refresh = UIHelper.actionButton("Refresh", HCS_Colors.BUTTON_BLUE);
         refresh.addActionListener(e -> loadTable());
         JButton view = UIHelper.detailsButton(this, table, "Patient Details");
@@ -99,7 +97,6 @@ public class AdminPatientsFrame extends JFrame {
         close.addActionListener(e -> AppNavigator.replace(this, new AdminDashboard(adminAccount)));
 
         buttons.add(update);
-        buttons.add(delete);
         buttons.add(refresh);
         buttons.add(view);
         buttons.add(close);
@@ -156,12 +153,4 @@ public class AdminPatientsFrame extends JFrame {
         }
     }
 
-    private void deletePatient() {
-        try {
-            service.deletePatient(UIHelper.selectedId(table, "patient_id"));
-            loadTable();
-        } catch (Exception ex) {
-            UIHelper.showError(this, ex);
-        }
-    }
 }

--- a/src/main/java/ie/setu/hcs/ui/AppointmentFrame.java
+++ b/src/main/java/ie/setu/hcs/ui/AppointmentFrame.java
@@ -286,6 +286,7 @@ public class AppointmentFrame extends JFrame {
     private void loadTable() {
         try {
             if (mode == Mode.PATIENT) {
+                clearOtherPatientSelections(null);
                 pendingTable.setModel(service.getPendingAppointmentsForPatient(account));
                 acceptedTable.setModel(service.getAcceptedAppointmentsForPatient(account));
                 cancelledTable.setModel(service.getCancelledAppointmentsForPatient(account));
@@ -296,6 +297,7 @@ public class AppointmentFrame extends JFrame {
                 UIHelper.hideColumns(pastTable, "appointment_id");
                 refreshAvailableSlots(null);
             } else {
+                table.clearSelection();
                 DefaultTableModel model = switch (mode) {
                     case PATIENT -> new DefaultTableModel();
                     case DOCTOR -> service.getAppointmentsForDoctor(account);
@@ -303,6 +305,7 @@ public class AppointmentFrame extends JFrame {
                 };
                 table.setModel(model);
                 UIHelper.hideColumns(table, "appointment_id");
+                table.clearSelection();
                 refreshAdminUpdateState();
             }
         } catch (Exception ex) {
@@ -479,7 +482,8 @@ public class AppointmentFrame extends JFrame {
     }
 
     private boolean hasPendingSelection(JTable sourceTable) {
-        if (sourceTable.getSelectedRow() < 0) {
+        Integer modelRow = UIHelper.selectedModelRow(sourceTable);
+        if (modelRow == null) {
             return false;
         }
 
@@ -489,7 +493,6 @@ public class AppointmentFrame extends JFrame {
             return false;
         }
 
-        int modelRow = sourceTable.convertRowIndexToModel(sourceTable.getSelectedRow());
         Object status = model.getValueAt(modelRow, statusColumn);
         return status != null && AppointmentService.STATUS_PENDING.equalsIgnoreCase(status.toString().trim());
     }

--- a/src/main/java/ie/setu/hcs/ui/ConsultationFrame.java
+++ b/src/main/java/ie/setu/hcs/ui/ConsultationFrame.java
@@ -305,9 +305,8 @@ public class ConsultationFrame extends JFrame {
     }
 
     private Integer selectedAppointmentIdForFollowUp() {
-        int selectedRow = table.getSelectedRow();
-        if (selectedRow >= 0) {
-            int row = table.convertRowIndexToModel(selectedRow);
+        Integer row = UIHelper.selectedModelRow(table);
+        if (row != null) {
             return intValue(row, "appointment_id");
         }
 
@@ -339,12 +338,10 @@ public class ConsultationFrame extends JFrame {
     }
 
     private void populateFromSelection() {
-        int selectedRow = table.getSelectedRow();
-        if (selectedRow < 0) {
+        Integer row = UIHelper.selectedModelRow(table);
+        if (row == null) {
             return;
         }
-
-        int row = table.convertRowIndexToModel(selectedRow);
         Integer appointmentId = intValue(row, "appointment_id");
         txtDiagnosis.setText(value(row, "diagnosis"));
         txtNotes.setText(value(row, "notes"));

--- a/src/main/java/ie/setu/hcs/ui/InsuranceFrame.java
+++ b/src/main/java/ie/setu/hcs/ui/InsuranceFrame.java
@@ -181,10 +181,12 @@ public class InsuranceFrame extends JFrame {
 
     private void loadTable() {
         try {
+            table.clearSelection();
             table.setModel(mode == Mode.PATIENT
                     ? service.getInsuranceForPatient(account)
                     : service.getAllInsurance());
             UIHelper.hideColumns(table, "insurance_id");
+            table.clearSelection();
             refreshUpdateState();
         } catch (Exception ex) {
             UIHelper.showError(this, ex);
@@ -308,7 +310,8 @@ public class InsuranceFrame extends JFrame {
     }
 
     private boolean hasPendingSelection() {
-        if (table.getSelectedRow() < 0) {
+        Integer modelRow = UIHelper.selectedModelRow(table);
+        if (modelRow == null) {
             return false;
         }
 
@@ -318,7 +321,6 @@ public class InsuranceFrame extends JFrame {
             return false;
         }
 
-        int modelRow = table.convertRowIndexToModel(table.getSelectedRow());
         Object status = model.getValueAt(modelRow, statusColumn);
         return status != null && InsuranceService.STATUS_PENDING_VERIFICATION.equalsIgnoreCase(status.toString().trim());
     }

--- a/src/main/java/ie/setu/hcs/ui/InvoiceFrame.java
+++ b/src/main/java/ie/setu/hcs/ui/InvoiceFrame.java
@@ -224,12 +224,11 @@ public class InvoiceFrame extends JFrame {
     }
 
     private String selectedValue(String columnName) {
-        int selectedRow = table.getSelectedRow();
-        if (selectedRow < 0) {
+        Integer modelRow = UIHelper.selectedModelRow(table);
+        if (modelRow == null) {
             return "";
         }
 
-        int modelRow = table.convertRowIndexToModel(selectedRow);
         int column = ((DefaultTableModel) table.getModel()).findColumn(columnName);
         if (column < 0) {
             return "";

--- a/src/main/java/ie/setu/hcs/ui/MedicalRecordsFrame.java
+++ b/src/main/java/ie/setu/hcs/ui/MedicalRecordsFrame.java
@@ -136,12 +136,10 @@ public class MedicalRecordsFrame extends JFrame {
     }
 
     private void populateFromSelection() {
-        int selectedRow = table.getSelectedRow();
-        if (selectedRow < 0) {
+        Integer row = UIHelper.selectedModelRow(table);
+        if (row == null) {
             return;
         }
-
-        int row = table.convertRowIndexToModel(selectedRow);
         txtDiagnosis.setText(value(row, "diagnosis"));
         if (mode != Mode.PATIENT) {
             txtNotes.setText(value(row, "notes"));

--- a/src/main/java/ie/setu/hcs/ui/ProfileFrame.java
+++ b/src/main/java/ie/setu/hcs/ui/ProfileFrame.java
@@ -94,7 +94,7 @@ public class ProfileFrame extends JFrame {
     }
 
     private JFrame backFrame() {
-        if (Boolean.TRUE.equals(account.isAdmin()) || Integer.valueOf(4).equals(account.getRoleId())) {
+        if (Integer.valueOf(4).equals(account.getRoleId())) {
             return new AdminDashboard(account);
         }
 
@@ -107,7 +107,7 @@ public class ProfileFrame extends JFrame {
     }
 
     private String roleName() {
-        if (Boolean.TRUE.equals(account.isAdmin()) || Integer.valueOf(4).equals(account.getRoleId())) {
+        if (Integer.valueOf(4).equals(account.getRoleId())) {
             return "Administrator";
         }
 

--- a/src/main/java/ie/setu/hcs/util/UIHelper.java
+++ b/src/main/java/ie/setu/hcs/util/UIHelper.java
@@ -970,12 +970,10 @@ public final class UIHelper {
     }
 
     public static void showSelectedRowDetails(Component parent, JTable table, String title) throws Exception {
-        int selectedRow = table.getSelectedRow();
-        if (selectedRow < 0) {
+        Integer modelRow = selectedModelRow(table);
+        if (modelRow == null) {
             throw new ValidationException("Please select a row first.");
         }
-
-        int modelRow = table.convertRowIndexToModel(selectedRow);
         showRowDetails(parent, table, modelRow, title);
     }
 
@@ -1042,12 +1040,11 @@ public final class UIHelper {
     }
 
     public static Integer selectedId(JTable table, String columnName) {
-        int selectedRow = table.getSelectedRow();
-        if (selectedRow < 0) {
+        Integer modelRow = selectedModelRow(table);
+        if (modelRow == null) {
             return null;
         }
 
-        int modelRow = table.convertRowIndexToModel(selectedRow);
         int column = table.getModel() instanceof DefaultTableModel
                 ? ((DefaultTableModel) table.getModel()).findColumn(columnName)
                 : -1;
@@ -1058,6 +1055,30 @@ public final class UIHelper {
 
         Object value = table.getModel().getValueAt(modelRow, column);
         return value == null ? null : Integer.parseInt(value.toString());
+    }
+
+    public static Integer selectedModelRow(JTable table) {
+        if (table == null || table.getModel() == null) {
+            return null;
+        }
+
+        int selectedRow = table.getSelectedRow();
+        if (selectedRow < 0 || selectedRow >= table.getRowCount()) {
+            table.clearSelection();
+            return null;
+        }
+
+        try {
+            int modelRow = table.convertRowIndexToModel(selectedRow);
+            if (modelRow < 0 || modelRow >= table.getModel().getRowCount()) {
+                table.clearSelection();
+                return null;
+            }
+            return modelRow;
+        } catch (RuntimeException ex) {
+            table.clearSelection();
+            return null;
+        }
     }
 
     public static void hideColumns(JTable table, String... columnNames) {
@@ -1208,18 +1229,20 @@ public final class UIHelper {
         }
 
         TableColumnModel columns = table.getColumnModel();
+        TableModel model = table.getModel();
         FontMetrics cellMetrics = table.getFontMetrics(table.getFont());
         FontMetrics headerMetrics = table.getTableHeader().getFontMetrics(table.getTableHeader().getFont());
-        int sampleRows = Math.min(table.getRowCount(), 50);
+        int sampleRows = Math.min(model.getRowCount(), 50);
         int[] baseWidths = new int[table.getColumnCount()];
 
         for (int columnIndex = 0; columnIndex < table.getColumnCount(); columnIndex++) {
             TableColumn column = columns.getColumn(columnIndex);
             Object headerValue = column.getHeaderValue();
             int preferred = headerMetrics.stringWidth(headerValue == null ? "" : headerValue.toString()) + 32;
+            int modelColumnIndex = table.convertColumnIndexToModel(columnIndex);
 
             for (int row = 0; row < sampleRows; row++) {
-                Object value = table.getValueAt(row, columnIndex);
+                Object value = model.getValueAt(row, modelColumnIndex);
                 preferred = Math.max(preferred, cellMetrics.stringWidth(value == null ? "" : value.toString()) + 28);
             }
 

--- a/src/main/resources/hospital_consultation_db.sql
+++ b/src/main/resources/hospital_consultation_db.sql
@@ -3,7 +3,7 @@
 -- https://www.phpmyadmin.net/
 --
 -- Host: localhost
--- Generation Time: Apr 21, 2026 at 02:11 PM
+-- Generation Time: Apr 21, 2026 at 02:30 PM
 -- Server version: 10.4.28-MariaDB
 -- PHP Version: 8.2.4
 
@@ -90,7 +90,7 @@ CREATE TABLE `appointments` (
   `status` varchar(30) NOT NULL,
   `medical_need` text DEFAULT NULL,
   `consultation_room` varchar(120) DEFAULT NULL,
-  `delete_flag` int(11) NOT NULL DEFAULT 0
+  `delete_flag` tinyint(1) NOT NULL DEFAULT 0
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --
@@ -125,7 +125,7 @@ CREATE TABLE `consultation` (
   `diagnosis` text NOT NULL,
   `notes` text NOT NULL,
   `created_at` timestamp NOT NULL DEFAULT current_timestamp(),
-  `delete_flag` int(11) DEFAULT 0
+  `delete_flag` tinyint(1) DEFAULT 0
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --
@@ -146,7 +146,7 @@ INSERT INTO `consultation` (`consultation_id`, `appointment_id`, `diagnosis`, `n
 CREATE TABLE `departments` (
   `dep_id` int(11) NOT NULL,
   `name` varchar(40) NOT NULL,
-  `delete_flag` int(11) NOT NULL DEFAULT 0
+  `delete_flag` tinyint(1) NOT NULL DEFAULT 0
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --
@@ -199,7 +199,7 @@ CREATE TABLE `insurance` (
   `status` varchar(30) NOT NULL,
   `expiration_date` date NOT NULL,
   `card_document_path` varchar(512) DEFAULT NULL,
-  `delete_flag` int(11) NOT NULL DEFAULT 0
+  `delete_flag` tinyint(1) NOT NULL DEFAULT 0
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --
@@ -225,7 +225,7 @@ CREATE TABLE `invoices` (
   `invoice_status` varchar(30) NOT NULL,
   `issued_at` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
   `paid_at` timestamp NULL DEFAULT NULL,
-  `delete_flag` int(11) NOT NULL DEFAULT 0
+  `delete_flag` tinyint(1) NOT NULL DEFAULT 0
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --
@@ -250,7 +250,7 @@ CREATE TABLE `lab_results` (
   `result` text NOT NULL,
   `uploaded_at` timestamp NOT NULL DEFAULT current_timestamp(),
   `appointment_id` int(11) DEFAULT NULL,
-  `delete_flag` int(11) NOT NULL DEFAULT 0
+  `delete_flag` tinyint(1) NOT NULL DEFAULT 0
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --
@@ -295,7 +295,7 @@ CREATE TABLE `medical_records` (
   `consultation_id` int(11) NOT NULL,
   `prescription` text NOT NULL,
   `created_at` timestamp NOT NULL DEFAULT current_timestamp(),
-  `delete_flag` int(11) NOT NULL DEFAULT 0
+  `delete_flag` tinyint(1) NOT NULL DEFAULT 0
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --

--- a/src/main/resources/hospital_consultation_db.sql
+++ b/src/main/resources/hospital_consultation_db.sql
@@ -3,7 +3,7 @@
 -- https://www.phpmyadmin.net/
 --
 -- Host: localhost
--- Generation Time: Apr 17, 2026 at 04:11 PM
+-- Generation Time: Apr 21, 2026 at 02:11 PM
 -- Server version: 10.4.28-MariaDB
 -- PHP Version: 8.2.4
 
@@ -38,19 +38,22 @@ CREATE TABLE `accounts` (
   `phone` varchar(50) NOT NULL,
   `gender` varchar(20) NOT NULL,
   `is_active` tinyint(1) NOT NULL DEFAULT 1,
-  `created_at` timestamp NOT NULL DEFAULT current_timestamp(),
-  `is_admin` tinyint(1) NOT NULL DEFAULT 0
+  `created_at` timestamp NOT NULL DEFAULT current_timestamp()
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --
 -- Dumping data for table `accounts`
 --
 
-INSERT INTO `accounts` (`account_id`, `email`, `password_hash`, `role_id`, `first_name`, `last_name`, `ppsn`, `phone`, `gender`, `is_active`, `created_at`, `is_admin`) VALUES
-(9, 'jay@icloud.com', 'c49ea13013272ea0e3e7e9ad1a99035fb50454044d801ba4ddbcf6ca3fb517b4', 2, 'Jay', 'Klepetz', 'lkjdfads', '0873234323', 'Male', 1, '2026-02-21 21:18:57', 0),
-(25, 'lufe@icloud.com', '03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4', 1, 'jack', 'lufe', '9218343F', '0878349343', 'Male', 1, '2026-02-22 16:59:56', 0),
-(28, 'kevin@icloud.com', '487891b2988ab53db16fe5c4f0b10df3b3a867b8cf06302d7dd51a3ef0f510e3', 3, 'kevin', 'qe', '2384371A', '0842983423', 'Male', 1, '2026-04-10 17:55:32', 0),
-(30, 'grace@icloud.com', 'a36f9fa98e5b8ddbb27852af79c8b3e0bec32b5e425375ebc064b98270901386', 4, 'grace', 'ivo', '9238742A', '0873234234', 'Male', 1, '2026-04-10 18:08:09', 1);
+INSERT INTO `accounts` (`account_id`, `email`, `password_hash`, `role_id`, `first_name`, `last_name`, `ppsn`, `phone`, `gender`, `is_active`, `created_at`) VALUES
+(9, 'jay@icloud.com', 'c49ea13013272ea0e3e7e9ad1a99035fb50454044d801ba4ddbcf6ca3fb517b4', 2, 'Jay', 'Klepetz', 'lkjdfads', '0873234323', 'Male', 1, '2026-02-21 21:18:57'),
+(25, 'lufe@icloud.com', '03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4', 1, 'jack', 'lufe', '9218343F', '0878349343', 'Male', 1, '2026-02-22 16:59:56'),
+(28, 'kevin@icloud.com', '487891b2988ab53db16fe5c4f0b10df3b3a867b8cf06302d7dd51a3ef0f510e3', 3, 'kevin', 'qe', '2384371A', '0842983423', 'Male', 1, '2026-04-10 17:55:32'),
+(30, 'grace@icloud.com', 'a36f9fa98e5b8ddbb27852af79c8b3e0bec32b5e425375ebc064b98270901386', 4, 'grace', 'ivo', '9238742A', '0873234234', 'Male', 1, '2026-04-10 18:08:09'),
+(31, 'levi@icloud.com', 'd0e9023ad21931225d5fc9d957e55e335338cd8857372ab9d4cc2c1ee785f729', 2, 'Levi', 'Ross', '3279347A', '0844738423', 'Male', 1, '2026-04-17 18:51:21'),
+(32, 'Paul@icloud.com', '7ea2b416fb49af99057cc2c88347530838567a330cbb36cd3f5bd67e35c0a7a8', 1, 'Paul', 'Mk', '2039847A', '0848342343', 'Male', 1, '2026-04-17 18:53:55'),
+(33, 'kier@icloud.com', 'b51e211fc3138812e22d39c974c289dbb0ed6360a94a1559dfbd802aef7469bf', 1, 'Liam', 'Kier', '2341342A', '0834313423', 'Male', 1, '2026-04-18 16:53:41'),
+(35, 'noer@icloud.com', '76ef7354917a1a944aec848c6f4f782e43ea54e3f36409960ee562cbd46cceeb', 1, 'Emma', 'Noer', '0983274A', '0860283423', 'Female', 1, '2026-04-20 15:07:51');
 
 -- --------------------------------------------------------
 
@@ -86,21 +89,29 @@ CREATE TABLE `appointments` (
   `appointment_datetime` datetime NOT NULL,
   `status` varchar(30) NOT NULL,
   `medical_need` text DEFAULT NULL,
-  `consultation_room` varchar(120) DEFAULT NULL
+  `consultation_room` varchar(120) DEFAULT NULL,
+  `delete_flag` int(11) NOT NULL DEFAULT 0
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --
 -- Dumping data for table `appointments`
 --
 
-INSERT INTO `appointments` (`appointment_id`, `patient_id`, `doctor_id`, `appointment_datetime`, `status`, `medical_need`, `consultation_room`) VALUES
-(1, 3, 1, '2026-04-10 09:00:00', 'Completed', NULL, NULL),
-(2, 3, 1, '2026-04-10 09:00:00', 'Pending', NULL, NULL),
-(3, 3, 1, '2026-04-10 10:00:00', 'Pending', 'fe', ''),
-(4, 3, 1, '2026-04-12 12:00:00', 'Pending', 'helrae', ''),
-(5, 3, 1, '2026-04-13 11:00:00', 'Completed', 'fef', NULL),
-(6, 3, 1, '2026-04-13 11:00:00', 'Rejected', 'fef', NULL),
-(7, 3, 1, '2026-04-21 16:00:00', 'Pending', 'Follow-up for Acute upper respiratory infection (common cold)', '123A');
+INSERT INTO `appointments` (`appointment_id`, `patient_id`, `doctor_id`, `appointment_datetime`, `status`, `medical_need`, `consultation_room`, `delete_flag`) VALUES
+(1, 3, 1, '2026-04-10 09:00:00', 'Completed', NULL, NULL, 1),
+(2, 3, 1, '2026-04-10 09:00:00', 'Pending', NULL, NULL, 1),
+(3, 3, 1, '2026-04-10 10:00:00', 'Pending', 'fe', '', 1),
+(4, 3, 1, '2026-04-12 12:00:00', 'Pending', 'helrae', '', 1),
+(5, 3, 1, '2026-04-13 11:00:00', 'Completed', 'fef', NULL, 1),
+(6, 3, 1, '2026-04-13 11:00:00', 'Rejected', 'fef', NULL, 1),
+(7, 3, 1, '2026-04-21 16:20:00', 'Accepted', 'Follow-up for Acute upper respiratory infection (common cold)', '123A', 1),
+(8, 3, 1, '2026-04-17 09:00:00', 'Pending', 'fjfde', '', 1),
+(10, 3, 1, '2026-05-12 14:00:00', 'Completed', 'xanax', '70B', 1),
+(11, 5, 5, '2026-05-12 14:00:00', 'Pending', 'illness, sore throat', '', 1),
+(12, 3, 5, '2026-04-17 09:00:00', 'Pending', 'fef', '', 1),
+(13, 6, 5, '2026-04-20 14:00:00', 'Accepted', 'Keep help', '', 0),
+(14, 3, 1, '2026-04-19 09:00:00', 'Pending', 'f', '', 1),
+(16, 7, 5, '2026-04-20 16:00:00', 'Accepted', 'The knee hurts', '', 0);
 
 -- --------------------------------------------------------
 
@@ -113,16 +124,18 @@ CREATE TABLE `consultation` (
   `appointment_id` int(11) NOT NULL,
   `diagnosis` text NOT NULL,
   `notes` text NOT NULL,
-  `created_at` timestamp NOT NULL DEFAULT current_timestamp()
+  `created_at` timestamp NOT NULL DEFAULT current_timestamp(),
+  `delete_flag` int(11) DEFAULT 0
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --
 -- Dumping data for table `consultation`
 --
 
-INSERT INTO `consultation` (`consultation_id`, `appointment_id`, `diagnosis`, `notes`, `created_at`) VALUES
-(1, 1, 'Acute upper respiratory infection (common cold)w', 'Patient reports sore throat, mild fever (37.8°C), and nasal congestion for 3 days. No history of chronic illness. Advised rest and hydration.', '2026-04-14 12:21:26'),
-(4, 5, 'heriu', '', '2026-04-14 09:18:09');
+INSERT INTO `consultation` (`consultation_id`, `appointment_id`, `diagnosis`, `notes`, `created_at`, `delete_flag`) VALUES
+(1, 1, 'Acute upper respiratory infection (common cold)', 'Patient reports sore throat, mild fever (37.8°C), and nasal congestion for 3 days. No history of chronic illness. Advised rest and hydration.', '2026-04-17 16:54:45', 1),
+(4, 5, 'heriu', '', '2026-04-14 09:18:09', 0),
+(5, 10, 'Acute bronchitis with mild wheezing', 'Patient reports 5-day history of persistent cough, worse at night. Mild chest discomfort and fatigue present. No fever currently. History of seasonal allergies. Lungs show mild wheeze on auscultation. Oxygen saturation normal.', '2026-04-17 18:38:52', 0);
 
 -- --------------------------------------------------------
 
@@ -132,18 +145,20 @@ INSERT INTO `consultation` (`consultation_id`, `appointment_id`, `diagnosis`, `n
 
 CREATE TABLE `departments` (
   `dep_id` int(11) NOT NULL,
-  `name` varchar(40) NOT NULL
+  `name` varchar(40) NOT NULL,
+  `delete_flag` int(11) NOT NULL DEFAULT 0
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --
 -- Dumping data for table `departments`
 --
 
-INSERT INTO `departments` (`dep_id`, `name`) VALUES
-(1, 'Cardiology'),
-(2, 'Neurology'),
-(3, 'Hospital Administration'),
-(4, 'General Practice');
+INSERT INTO `departments` (`dep_id`, `name`, `delete_flag`) VALUES
+(1, 'Cardiology', 0),
+(2, 'Neurology', 0),
+(3, 'Hospital Administration', 0),
+(4, 'General Practice', 0),
+(5, 'Surgery', 0);
 
 -- --------------------------------------------------------
 
@@ -154,20 +169,21 @@ INSERT INTO `departments` (`dep_id`, `name`) VALUES
 CREATE TABLE `doctors` (
   `doctor_id` int(11) NOT NULL,
   `account_id` int(11) NOT NULL,
-  `employee_num` varchar(50) DEFAULT NULL,
   `specialization` varchar(100) NOT NULL,
   `license_number` varchar(20) NOT NULL,
   `years_of_experience` int(5) NOT NULL,
   `consultation_fee` int(10) NOT NULL,
-  `dep_id` int(11) NOT NULL
+  `dep_id` int(11) NOT NULL,
+  `employee_num` varchar(50) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --
 -- Dumping data for table `doctors`
 --
 
-INSERT INTO `doctors` (`doctor_id`, `account_id`, `employee_num`, `specialization`, `license_number`, `years_of_experience`, `consultation_fee`, `dep_id`) VALUES
-(1, 9, 'DOC-1001', 'Neurologist', '3928473', 3, 0, 2);
+INSERT INTO `doctors` (`doctor_id`, `account_id`, `specialization`, `license_number`, `years_of_experience`, `consultation_fee`, `dep_id`, `employee_num`) VALUES
+(1, 9, 'Neurologist', '3928473', 3, 0, 2, '0'),
+(5, 31, 'Surgent', '2934719023748', 3, 0, 5, '0');
 
 -- --------------------------------------------------------
 
@@ -182,16 +198,18 @@ CREATE TABLE `insurance` (
   `policy_number` varchar(50) NOT NULL,
   `status` varchar(30) NOT NULL,
   `expiration_date` date NOT NULL,
-  `card_document_path` varchar(512) DEFAULT NULL
+  `card_document_path` varchar(512) DEFAULT NULL,
+  `delete_flag` int(11) NOT NULL DEFAULT 0
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --
 -- Dumping data for table `insurance`
 --
 
-INSERT INTO `insurance` (`insurance_id`, `patient_id`, `provider_name`, `policy_number`, `status`, `expiration_date`, `card_document_path`) VALUES
-(3, 3, 'lufe', 'efe', 'Active', '2027-04-12', NULL),
-(4, 3, 'fkewf', 'HS-029837425', 'Pending Verification', '2027-04-13', '/Users/thomas/Documents/ProgrammeSETU/A_C/AssemblyAndC_2025_2026/PRACTICAL_10/PORT.png');
+INSERT INTO `insurance` (`insurance_id`, `patient_id`, `provider_name`, `policy_number`, `status`, `expiration_date`, `card_document_path`, `delete_flag`) VALUES
+(4, 3, 'fkewf', 'HS-029837425', 'Verified', '2027-04-13', '/Users/thomas/Documents/ProgrammeSETU/A_C/AssemblyAndC_2025_2026/PRACTICAL_10/PORT.png', 0),
+(5, 5, '3k', 'HS-392874320', 'Pending Verification', '2027-04-17', '/Users/thomas/Pictures/Pictures/Avatar/wallhaven-1pjw21.jpg', 0),
+(6, 7, 'Dublin 8', 'HS-823741232', 'Verified', '2027-04-20', '/Users/thomas/Pictures/Pictures/Wallpaper/wallpaper (101).jpg', 0);
 
 -- --------------------------------------------------------
 
@@ -206,16 +224,17 @@ CREATE TABLE `invoices` (
   `amount` int(11) NOT NULL,
   `invoice_status` varchar(30) NOT NULL,
   `issued_at` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
-  `paid_at` timestamp NULL DEFAULT NULL
+  `paid_at` timestamp NULL DEFAULT NULL,
+  `delete_flag` int(11) NOT NULL DEFAULT 0
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --
 -- Dumping data for table `invoices`
 --
 
-INSERT INTO `invoices` (`invoice_id`, `patient_id`, `consultation_id`, `amount`, `invoice_status`, `issued_at`, `paid_at`) VALUES
-(1, 3, 1, 50, 'PAID', '2026-04-14 08:52:09', '2026-04-14 08:52:09'),
-(4, 3, 4, 23123, 'PAID', '2026-04-17 10:42:09', '2026-04-17 10:42:09');
+INSERT INTO `invoices` (`invoice_id`, `patient_id`, `consultation_id`, `amount`, `invoice_status`, `issued_at`, `paid_at`, `delete_flag`) VALUES
+(4, 3, 4, 23123, 'PAID', '2026-04-17 18:32:30', '2026-04-17 18:32:30', 0),
+(5, 3, 5, 85, 'UNPAID', '2026-04-17 18:38:52', NULL, 0);
 
 -- --------------------------------------------------------
 
@@ -230,16 +249,17 @@ CREATE TABLE `lab_results` (
   `test_type` varchar(40) NOT NULL,
   `result` text NOT NULL,
   `uploaded_at` timestamp NOT NULL DEFAULT current_timestamp(),
-  `appointment_id` int(11) DEFAULT NULL
+  `appointment_id` int(11) DEFAULT NULL,
+  `delete_flag` int(11) NOT NULL DEFAULT 0
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --
 -- Dumping data for table `lab_results`
 --
 
-INSERT INTO `lab_results` (`lab_result_id`, `consultation_id`, `technician_id`, `test_type`, `result`, `uploaded_at`, `appointment_id`) VALUES
-(1, 1, 3, 'werwerwe', 'werwerwerwer', '2026-04-10 18:14:35', NULL),
-(3, 4, 3, 'Kfjew', 'fekwfjwefwe', '2026-04-14 09:18:28', NULL);
+INSERT INTO `lab_results` (`lab_result_id`, `consultation_id`, `technician_id`, `test_type`, `result`, `uploaded_at`, `appointment_id`, `delete_flag`) VALUES
+(1, 1, 3, 'werwerwe', 'werwerwerwer', '2026-04-10 18:14:35', NULL, 1),
+(3, 4, 3, 'Kfjew', 'fekwfjwefwe', '2026-04-14 09:18:28', NULL, 1);
 
 -- --------------------------------------------------------
 
@@ -274,16 +294,18 @@ CREATE TABLE `medical_records` (
   `patient_id` int(11) NOT NULL,
   `consultation_id` int(11) NOT NULL,
   `prescription` text NOT NULL,
-  `created_at` timestamp NOT NULL DEFAULT current_timestamp()
+  `created_at` timestamp NOT NULL DEFAULT current_timestamp(),
+  `delete_flag` int(11) NOT NULL DEFAULT 0
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --
 -- Dumping data for table `medical_records`
 --
 
-INSERT INTO `medical_records` (`record_id`, `patient_id`, `consultation_id`, `prescription`, `created_at`) VALUES
-(1, 3, 1, 'Paracetamol 500mg – take 1 tablet every 6 hours as needed\nIbuprofen 200mg – take 1 tablet every 8 hours after meals\nSaline nasal spray – use twice daily', '2026-04-14 12:21:26'),
-(4, 3, 4, 'efwef', '2026-04-14 09:18:09');
+INSERT INTO `medical_records` (`record_id`, `patient_id`, `consultation_id`, `prescription`, `created_at`, `delete_flag`) VALUES
+(1, 3, 1, 'Paracetamol 500mg – take 1 tablet every 6 hours as needed\nIbuprofen 200mg – take 1 tablet every 8 hours after meals\nSaline nasal spray – use twice daily', '2026-04-17 16:54:45', 1),
+(4, 3, 4, 'efwef', '2026-04-14 09:18:09', 0),
+(5, 3, 5, '• Amoxicillin 500mg – take 1 capsule 3 times daily for 7 days\n• Salbutamol inhaler – 2 puffs every 6 hours as needed\n• Paracetamol 500mg – 1–2 tablets every 6 hours for pain/fever (max 4g/day)\n• Rest and increase fluid intake', '2026-04-17 18:38:52', 0);
 
 -- --------------------------------------------------------
 
@@ -309,7 +331,11 @@ INSERT INTO `notifications` (`notification_id`, `patient_id`, `title`, `message`
 (2, 3, 'Appointment Rejected', 'Your appointment with Dr. Jay Klepetz on 13 Apr 2026 11:00 is now Rejected.', 1, '2026-04-14 09:48:55'),
 (3, 3, 'Appointment Completed', 'Your appointment with Dr. Jay Klepetz on 13 Apr 2026 11:00 is now Completed.', 1, '2026-04-14 10:14:23'),
 (4, 3, 'Appointment Accepted', 'Your appointment with Dr. Jay Klepetz on 13 Apr 2026 11:00 is now Accepted.', 1, '2026-04-14 10:16:15'),
-(5, 3, 'Follow-up scheduled', 'A follow-up appointment with Dr. Jay Klepetz has been scheduled for 21 Apr 2026 16:00. Reason: Follow-up for Acute upper respiratory infection (common cold).', 1, '2026-04-14 10:41:25');
+(5, 3, 'Follow-up scheduled', 'A follow-up appointment with Dr. Jay Klepetz has been scheduled for 21 Apr 2026 16:00. Reason: Follow-up for Acute upper respiratory infection (common cold).', 1, '2026-04-14 10:41:25'),
+(6, 3, 'Appointment Accepted', 'Your appointment with Dr. Jay Klepetz on 12 May 2026 14:00 is now Accepted.', 1, '2026-04-17 17:36:01'),
+(7, 3, 'Appointment Accepted', 'Your appointment with Dr. Jay Klepetz on 21 Apr 2026 16:00 is now Accepted. Assigned room: 123A.', 1, '2026-04-19 20:14:55'),
+(8, 6, 'Appointment Accepted', 'Your appointment with Dr. Levi Ross on 20 Apr 2026 14:00 is now Accepted.', 1, '2026-04-20 16:06:02'),
+(9, 7, 'Appointment Accepted', 'Your appointment with Dr. Levi Ross on 20 Apr 2026 16:00 is now Accepted.', 1, '2026-04-20 16:11:24');
 
 -- --------------------------------------------------------
 
@@ -332,7 +358,10 @@ CREATE TABLE `patients` (
 --
 
 INSERT INTO `patients` (`patient_id`, `account_id`, `date_of_birth`, `address`, `eircode`, `blood_type`, `medical_record_number`) VALUES
-(3, 25, '2003-11-22', 'Dublin', 'A43 F323', 'B1', '234132413');
+(3, 25, '2003-11-22', 'Dublin', 'A43 F323', 'B1', '234132413'),
+(5, 32, '2003-07-22', 'Dublin 2, At', 'F38 F3F3', 'B1', '23984732'),
+(6, 33, '2002-03-20', 'Waterford', 'F32 B3A8', 'A1', '583512882'),
+(7, 35, '2003-08-05', 'Cork, 1', 'F33 J3L1', 'A2', '177084996');
 
 -- --------------------------------------------------------
 
@@ -471,7 +500,7 @@ ALTER TABLE `roles`
 -- AUTO_INCREMENT for table `accounts`
 --
 ALTER TABLE `accounts`
-  MODIFY `account_id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=31;
+  MODIFY `account_id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=44;
 
 --
 -- AUTO_INCREMENT for table `administrators`
@@ -483,37 +512,37 @@ ALTER TABLE `administrators`
 -- AUTO_INCREMENT for table `appointments`
 --
 ALTER TABLE `appointments`
-  MODIFY `appointment_id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=8;
+  MODIFY `appointment_id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=18;
 
 --
 -- AUTO_INCREMENT for table `consultation`
 --
 ALTER TABLE `consultation`
-  MODIFY `consultation_id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=5;
+  MODIFY `consultation_id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=8;
 
 --
 -- AUTO_INCREMENT for table `departments`
 --
 ALTER TABLE `departments`
-  MODIFY `dep_id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=5;
+  MODIFY `dep_id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=6;
 
 --
 -- AUTO_INCREMENT for table `doctors`
 --
 ALTER TABLE `doctors`
-  MODIFY `doctor_id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=5;
+  MODIFY `doctor_id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=8;
 
 --
 -- AUTO_INCREMENT for table `insurance`
 --
 ALTER TABLE `insurance`
-  MODIFY `insurance_id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=5;
+  MODIFY `insurance_id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=7;
 
 --
 -- AUTO_INCREMENT for table `invoices`
 --
 ALTER TABLE `invoices`
-  MODIFY `invoice_id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=5;
+  MODIFY `invoice_id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=8;
 
 --
 -- AUTO_INCREMENT for table `lab_results`
@@ -531,19 +560,19 @@ ALTER TABLE `lab_technicians`
 -- AUTO_INCREMENT for table `medical_records`
 --
 ALTER TABLE `medical_records`
-  MODIFY `record_id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=5;
+  MODIFY `record_id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=8;
 
 --
 -- AUTO_INCREMENT for table `notifications`
 --
 ALTER TABLE `notifications`
-  MODIFY `notification_id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=6;
+  MODIFY `notification_id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=10;
 
 --
 -- AUTO_INCREMENT for table `patients`
 --
 ALTER TABLE `patients`
-  MODIFY `patient_id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=5;
+  MODIFY `patient_id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=9;
 
 --
 -- AUTO_INCREMENT for table `roles`

--- a/src/test/java/ie/setu/hcs/integration/TransactionRunnerIT.java
+++ b/src/test/java/ie/setu/hcs/integration/TransactionRunnerIT.java
@@ -32,7 +32,6 @@ class TransactionRunnerIT extends DatabaseIntegrationSupport {
                         "0870000001",
                         "Other",
                         true,
-                        false,
                         LocalDateTime.now()
                 );
                 accountDAO.save(conn, account);

--- a/src/test/java/ie/setu/hcs/service/AuthenticationServiceTest.java
+++ b/src/test/java/ie/setu/hcs/service/AuthenticationServiceTest.java
@@ -76,7 +76,6 @@ class AuthenticationServiceTest {
                 "0871234567",
                 "Male",
                 active,
-                false,
                 LocalDateTime.now()
         );
         account.setActive(active);


### PR DESCRIPTION
## Summary
This PR finalizes the recent admin and data-handling fixes on dev.

## Changes
- guard table selection after sort and refresh
- add soft-delete filtering for clinical records
- remove direct deletes from staff management screens
- remove isAdmin and keep admin access role-based
- migrate doctor employee numbers to text
- refresh the SQL dump to match current schema expectations

## Verification
- mvn -q -DskipTests compile
- mvn -q package